### PR TITLE
Fix #38: Accessibility: respect Reduce Motion for map and control animations

### DIFF
--- a/IsoMe/TEDesign.swift
+++ b/IsoMe/TEDesign.swift
@@ -90,6 +90,8 @@ struct TERow<Content: View>: View {
 /// TE-styled toggle: cream-paper-friendly off track with stronger border,
 /// solid accent on track. Gives clear contrast on TE.surface backgrounds.
 struct TEToggleStyle: ToggleStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private let trackWidth: CGFloat = 50
     private let trackHeight: CGFloat = 30
     private let thumbInset: CGFloat = 2
@@ -114,7 +116,7 @@ struct TEToggleStyle: ToggleStyle {
                     .padding(.horizontal, thumbInset)
             }
             .frame(width: trackWidth, height: trackHeight)
-            .animation(.easeInOut(duration: 0.18), value: isOn)
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: isOn)
             .contentShape(Capsule())
             .onTapGesture {
                 configuration.isOn.toggle()

--- a/IsoMe/Views/ContentView.swift
+++ b/IsoMe/Views/ContentView.swift
@@ -123,6 +123,7 @@ private struct MainTabView: View {
 }
 
 private struct OnboardingView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let viewModel: LocationViewModel
     let onComplete: (Bool) -> Void
 
@@ -163,7 +164,7 @@ private struct OnboardingView: View {
                         .tag(3)
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
-                .animation(.spring(response: 0.42, dampingFraction: 0.84), value: selectedPage)
+                .animation(reduceMotion ? nil : .spring(response: 0.42, dampingFraction: 0.84), value: selectedPage)
 
                 controls
                     .padding(.horizontal, 24)
@@ -174,7 +175,7 @@ private struct OnboardingView: View {
         .onChange(of: locationManager.authorizationStatus) { _, newStatus in
             guard selectedPage == 2 else { return }
             if newStatus == .authorizedAlways {
-                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                withAnimation(reduceMotion ? nil : .spring(response: 0.4, dampingFraction: 0.85)) {
                     selectedPage = 3
                 }
             }
@@ -412,7 +413,7 @@ private struct OnboardingView: View {
                 Capsule()
                     .fill(index <= selectedPage ? OnboardingPalette.accent : OnboardingPalette.border)
                     .frame(height: 4)
-                    .animation(.spring(response: 0.3, dampingFraction: 0.88), value: selectedPage)
+                    .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.88), value: selectedPage)
             }
         }
     }
@@ -421,7 +422,7 @@ private struct OnboardingView: View {
         HStack(spacing: 12) {
             if selectedPage > 0 {
                 Button {
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                    withAnimation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.85)) {
                         selectedPage -= 1
                     }
                 } label: {
@@ -473,7 +474,7 @@ private struct OnboardingView: View {
             return
         }
 
-        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+        withAnimation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.85)) {
             selectedPage += 1
         }
     }
@@ -672,6 +673,7 @@ private struct OnboardingChecklistRow: View {
 }
 
 private struct OnboardingSignalColumn: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let delay: Double
     @State private var isAnimating = false
 
@@ -684,13 +686,26 @@ private struct OnboardingSignalColumn: View {
             }
         }
         .onAppear {
-            withAnimation(
-                .easeInOut(duration: 1.0)
-                .repeatForever(autoreverses: true)
-                .delay(delay)
-            ) {
-                isAnimating = true
-            }
+            updateSignalAnimation(reduceMotion: reduceMotion)
+        }
+        .onChange(of: reduceMotion) { _, shouldReduceMotion in
+            updateSignalAnimation(reduceMotion: shouldReduceMotion)
+        }
+    }
+
+    private func updateSignalAnimation(reduceMotion: Bool) {
+        guard !reduceMotion else {
+            isAnimating = true
+            return
+        }
+
+        isAnimating = false
+        withAnimation(
+            .easeInOut(duration: 1.0)
+            .repeatForever(autoreverses: true)
+            .delay(delay)
+        ) {
+            isAnimating = true
         }
     }
 }
@@ -760,6 +775,8 @@ private extension View {
 }
 
 private struct OnboardingPrimaryButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.onboardingButton)
@@ -779,11 +796,13 @@ private struct OnboardingPrimaryButtonStyle: ButtonStyle {
             .shadow(color: OnboardingPalette.accent.opacity(0.24), radius: 10, x: 0, y: 6)
             .scaleEffect(configuration.isPressed ? 0.98 : 1)
             .opacity(configuration.isPressed ? 0.92 : 1)
-            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: configuration.isPressed)
     }
 }
 
 private struct OnboardingSecondaryButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.onboardingButton)
@@ -802,11 +821,13 @@ private struct OnboardingSecondaryButtonStyle: ButtonStyle {
             }
             .scaleEffect(configuration.isPressed ? 0.98 : 1)
             .opacity(configuration.isPressed ? 0.92 : 1)
-            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: configuration.isPressed)
     }
 }
 
 private struct OnboardingTextButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.onboardingMicro)
@@ -818,7 +839,7 @@ private struct OnboardingTextButtonStyle: ButtonStyle {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .fill(OnboardingPalette.card.opacity(configuration.isPressed ? 0.8 : 0.001))
             )
-            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: configuration.isPressed)
     }
 }
 

--- a/IsoMe/Views/MapView.swift
+++ b/IsoMe/Views/MapView.swift
@@ -3,6 +3,7 @@ import MapKit
 import SwiftData
 
 struct LocationMapView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Bindable var viewModel: LocationViewModel
     @ObservedObject private var locationManager: LocationManager
     @State private var selectedVisit: Visit?
@@ -165,7 +166,7 @@ struct LocationMapView: View {
                             .transition(.move(edge: .top).combined(with: .opacity))
                     }
                 }
-                .animation(.spring(response: 0.4, dampingFraction: 0.82), value: discordPromoDismissed)
+                .animation(reduceMotion ? nil : .spring(response: 0.4, dampingFraction: 0.82), value: discordPromoDismissed)
 
                 // Bottom liquid-glass tracking + filter controls
                 VStack(spacing: 8) {
@@ -216,7 +217,7 @@ struct LocationMapView: View {
                         }
 
                         FilterBarToggle(isOpen: showFilterBar) {
-                            withAnimation(.spring(response: 0.4, dampingFraction: 0.82)) {
+                            withAnimation(reduceMotion ? nil : .spring(response: 0.4, dampingFraction: 0.82)) {
                                 showFilterBar.toggle()
                             }
                         }
@@ -224,10 +225,10 @@ struct LocationMapView: View {
                 }
                 .padding(.horizontal, 12)
                 .padding(.bottom, 8)
-                .animation(.spring(response: 0.35, dampingFraction: 0.82), value: isTracking)
+                .animation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.82), value: isTracking)
                 .onChange(of: isTracking) { _, newValue in
                     if !newValue {
-                        withAnimation(.spring(response: 0.35, dampingFraction: 0.82)) {
+                        withAnimation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.82)) {
                             trackingPillExpanded = false
                         }
                     }
@@ -290,13 +291,13 @@ struct LocationMapView: View {
     }
 
     private func dismissDiscordPromo() {
-        withAnimation(.spring(response: 0.4, dampingFraction: 0.82)) {
+        withAnimation(reduceMotion ? nil : .spring(response: 0.4, dampingFraction: 0.82)) {
             discordPromoDismissed = true
         }
     }
 
     private func handleTrackingTap() {
-        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+        withAnimation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.8)) {
             if isTracking {
                 viewModel.stopTracking()
             } else {
@@ -309,6 +310,7 @@ struct LocationMapView: View {
 // MARK: - Tracking Control Pills
 
 struct MapTrackingControlPill: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Bindable var viewModel: LocationViewModel
     @ObservedObject var locationManager: LocationManager
     let isTracking: Bool
@@ -321,7 +323,7 @@ struct MapTrackingControlPill: View {
         HStack(spacing: 10) {
             if isTracking {
                 Button {
-                    withAnimation(.spring(response: 0.4, dampingFraction: 0.82)) {
+                    withAnimation(reduceMotion ? nil : .spring(response: 0.4, dampingFraction: 0.82)) {
                         isExpanded.toggle()
                     }
                 } label: {
@@ -363,9 +365,12 @@ struct MapTrackingControlPill: View {
                     .transition(.opacity)
             }
         }
-        .animation(.spring(response: 0.35, dampingFraction: 0.82), value: isTracking)
-        .animation(.spring(response: 0.35, dampingFraction: 0.82), value: isExpanded)
-        .onAppear { pulseOpacity = 0.35 }
+        .animation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.82), value: isTracking)
+        .animation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.82), value: isExpanded)
+        .onAppear { pulseOpacity = reduceMotion ? 1.0 : 0.35 }
+        .onChange(of: reduceMotion) { _, shouldReduceMotion in
+            pulseOpacity = shouldReduceMotion ? 1.0 : 0.35
+        }
     }
 
     private var statusBlock: some View {
@@ -375,9 +380,9 @@ struct MapTrackingControlPill: View {
                 .frame(width: 7, height: 7)
                 .opacity(isTracking ? pulseOpacity : 1.0)
                 .animation(
-                    isTracking
+                    isTracking && !reduceMotion
                         ? .easeInOut(duration: 1.2).repeatForever(autoreverses: true)
-                        : .default,
+                        : nil,
                     value: pulseOpacity
                 )
 
@@ -387,7 +392,7 @@ struct MapTrackingControlPill: View {
                         .font(TE.mono(.subheadline, weight: .semibold))
                         .foregroundStyle(TE.textMuted)
                         .monospacedDigit()
-                        .contentTransition(.numericText())
+                        .contentTransition(reduceMotion ? .identity : .numericText())
                 }
             } else {
                 Text("STANDBY")
@@ -491,6 +496,7 @@ struct MapAutoOffPill: View {
 }
 
 struct VisitMarker: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let visit: Visit
     let isSelected: Bool
 
@@ -510,7 +516,7 @@ struct VisitMarker: View {
                 .fill(visit.isCurrentVisit ? .blue : .red)
                 .frame(width: 10, height: 8)
         }
-        .animation(.spring(duration: 0.2), value: isSelected)
+        .animation(reduceMotion ? nil : .spring(duration: 0.2), value: isSelected)
     }
 }
 
@@ -528,6 +534,7 @@ struct Triangle: Shape {
 // MARK: - Path Start/End Markers
 
 struct PathStartMarker: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let timestamp: Date
     @State private var showingTooltip = false
     
@@ -554,7 +561,7 @@ struct PathStartMarker: View {
             .shadow(color: .green.opacity(0.4), radius: 4, y: 2)
         }
         .onTapGesture {
-            withAnimation(.spring(duration: 0.2)) {
+            withAnimation(reduceMotion ? nil : .spring(duration: 0.2)) {
                 showingTooltip.toggle()
             }
         }
@@ -562,6 +569,7 @@ struct PathStartMarker: View {
 }
 
 struct PathEndMarker: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let timestamp: Date
     @State private var showingTooltip = false
     
@@ -588,7 +596,7 @@ struct PathEndMarker: View {
             .shadow(color: .red.opacity(0.4), radius: 4, y: 2)
         }
         .onTapGesture {
-            withAnimation(.spring(duration: 0.2)) {
+            withAnimation(reduceMotion ? nil : .spring(duration: 0.2)) {
                 showingTooltip.toggle()
             }
         }
@@ -816,6 +824,7 @@ enum MapDatePreset: CaseIterable, Hashable {
 }
 
 struct FilterBarToggle: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let isOpen: Bool
     let action: () -> Void
 
@@ -841,7 +850,7 @@ struct FilterBarToggle: View {
                         }
                         .shadow(color: .black.opacity(0.18), radius: 14, x: 0, y: 6)
                 }
-                .contentTransition(.symbolEffect(.replace))
+                .contentTransition(reduceMotion ? .identity : .symbolEffect(.replace))
         }
         .buttonStyle(.plain)
         .sensoryFeedback(.impact(flexibility: .soft), trigger: isOpen)
@@ -949,12 +958,13 @@ struct PresetPill: View {
 }
 
 struct LayerToggleButton: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let systemImage: String
     @Binding var isOn: Bool
 
     var body: some View {
         Button {
-            withAnimation(.spring(duration: 0.25)) {
+            withAnimation(reduceMotion ? nil : .spring(duration: 0.25)) {
                 isOn.toggle()
             }
         } label: {

--- a/IsoMe/Views/SessionPathMapView.swift
+++ b/IsoMe/Views/SessionPathMapView.swift
@@ -4,6 +4,7 @@ import MapKit
 /// A map view that displays a session's recorded path with start/end markers
 /// and a gradient polyline showing direction of travel
 struct SessionPathMapView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let points: [LocationPoint]
     @State private var cameraPosition: MapCameraPosition = .automatic
     
@@ -78,7 +79,7 @@ struct SessionPathMapView: View {
         let coordinates = points.map { $0.coordinate }
         let region = MKCoordinateRegion(coordinates: coordinates, padding: 1.3)
         
-        withAnimation(.easeInOut(duration: 0.3)) {
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.3)) {
             cameraPosition = .region(region)
         }
     }
@@ -102,6 +103,7 @@ struct StartMarker: View {
 }
 
 struct CurrentLocationMarker: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPulsing = false
     
     var body: some View {
@@ -123,12 +125,25 @@ struct CurrentLocationMarker: View {
         }
         .shadow(color: .blue.opacity(0.3), radius: 4, y: 2)
         .onAppear {
-            withAnimation(
-                .easeInOut(duration: 1.5)
-                .repeatForever(autoreverses: false)
-            ) {
-                isPulsing = true
-            }
+            updatePulseAnimation(reduceMotion: reduceMotion)
+        }
+        .onChange(of: reduceMotion) { _, shouldReduceMotion in
+            updatePulseAnimation(reduceMotion: shouldReduceMotion)
+        }
+    }
+
+    private func updatePulseAnimation(reduceMotion: Bool) {
+        guard !reduceMotion else {
+            isPulsing = false
+            return
+        }
+
+        isPulsing = false
+        withAnimation(
+            .easeInOut(duration: 1.5)
+            .repeatForever(autoreverses: false)
+        ) {
+            isPulsing = true
         }
     }
 }


### PR DESCRIPTION
Closes CodyBontecou/isome#38

Implemented by Symphony agent automation.

## Issue

https://github.com/CodyBontecou/isome/issues/38

## Simulator QA

Report: `.symphony/qa-report.md`
Artifact directory: `.symphony/qa-artifacts`

Screenshots: 5
Videos: 2
Other artifacts: 0

### .symphony/qa-artifacts/apple-account-alert.png

![.symphony/qa-artifacts/apple-account-alert.png](https://imghost.isolated.tech/d9a8b3e7.png)

- video: `.symphony/qa-artifacts/full-motion-controls.mp4`
### .symphony/qa-artifacts/full-motion-map-tracking.png

![.symphony/qa-artifacts/full-motion-map-tracking.png](https://imghost.isolated.tech/e1bc5366.png)

- video: [.symphony/qa-artifacts/reduce-motion-on-controls.mp4](https://imghost.isolated.tech/a3acc8ad.mp4)
### .symphony/qa-artifacts/reduce-motion-on-filter-open.png

![.symphony/qa-artifacts/reduce-motion-on-filter-open.png](https://imghost.isolated.tech/bd936e00.png)

### .symphony/qa-artifacts/reduce-motion-on-map-closed.png

![.symphony/qa-artifacts/reduce-motion-on-map-closed.png](https://imghost.isolated.tech/1c07dd83.png)

### .symphony/qa-artifacts/reduce-motion-on-tracking.png

![.symphony/qa-artifacts/reduce-motion-on-tracking.png](https://imghost.isolated.tech/334a0055.png)


<details>
<summary>QA report</summary>

# QA Report: CodyBontecou/isome#38

## Result

PASS.

## Simulator / Build

- Device: iPhone 17 Pro simulator, iOS 26.3 (`0335EECF-93B3-4F95-9D5E-DC339BC055DB`)
- App bundle: `com.bontecou.isome`
- Build: `xcodebuild -project IsoMe.xcodeproj -scheme IsoMe -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath .symphony/DerivedData build`
- Build result: succeeded

## Implementation Inspected

- `IsoMe/Views/MapView.swift`: added `@Environment(\.accessibilityReduceMotion)` and gates for banner/control springs, tracking pill expansion/collapse, tracking pulse, numeric timer transition, visit marker selection, start/end tooltip animation, filter symbol replacement, and layer toggles.
- `IsoMe/Views/SessionPathMapView.swift`: gates session camera fitting and the current-location repeat pulse.
- `IsoMe/Views/ContentView.swift`: gates onboarding tab/progress/button animations and the looping signal animation.
- `IsoMe/TEDesign.swift`: gates the shared `TEToggleStyle` animation.

## Mocked / Local Data Setup

- Used simulator-local data only.
- Launched with `hasCompletedOnboarding = YES` to avoid onboarding/auth flows.
- Launched with `allowNetworkGeocoding = NO` to avoid reverse-geocoding network calls.
- Granted simulator location permission with `xcrun simctl privacy ... grant location-always`.
- Injected deterministic San Francisco simulator GPS points with `xcrun simctl location set/start`.
- Did not use production auth, production APIs, real accounts, StoreKit purchase flows, or real user data.

## Steps Performed

1. Inspected the source diff and searched the requested map/control areas for remaining `withAnimation`, `.animation`, `repeatForever`, spring, symbol, and numeric text transitions.
2. Built the app successfully for the iPhone 17 Pro simulator using DerivedData under `.symphony/DerivedData`.
3. Installed a fresh app build on the iPhone 17 Pro simulator.
4. Verified Reduce Motion disabled path:
   - Set `ReduceMotionEnabled = 0`.
   - Launched the app on the Map tab.
   - Tapped Play to start tracking.
   - Injected a deterministic simulator route.
   - Opened the map filter controls.
   - Captured screenshot and video evidence.
5. Verified Reduce Motion enabled path:
   - Set `ReduceMotionEnabled = 1`.
   - Relaunched the app on the Map tab.
   - Tapped Play to start tracking.
   - Injected the same style deterministic simulator route.
   - Confirmed tracking timer, stop control, session path, Session Start marker, Current marker, and expanded filter controls remained understandable without spring/pulse motion.
   - Captured screenshot and video evidence.
6. Dismissed a system Apple Account alert with Cancel when it appeared.
7. Ran `git diff --check`; no whitespace errors.

## Artifacts

- `apple-account-alert.png`
- `full-motion-controls.mp4`
- `full-motion-map-tracking.png`
- `reduce-motion-on-controls.mp4`
- `reduce-motion-on-map-closed.png`
- `reduce-motion-on-tracking.png`
- `reduce-motion-on-filter-open.png`

## Notes

- The reduced-motion video shows the tracking and filter-control state changes completing without the continuous pulse/spring effects used by the default path.
- The full-motion screenshot/video confirm default behavior is still active when Reduce Motion is disabled.
- System Apple Account prompt was captured and dismissed with Cancel; no sign-in or purchase flow was used.

</details>

## Notes for reviewer

- Review generated changes carefully before merge.
- Verify tests/builds relevant to this repository.

- QA screenshots/videos are uploaded externally and embedded/linked above.
