### PR TITLE
ISO-216: Accessibility: add VoiceOver labels/values for map annotations and session paths

### DIFF
--- a/IsoMe/Models/LocationPoint.swift
+++ b/IsoMe/Models/LocationPoint.swift
@@ -53,6 +53,36 @@ final class LocationPoint {
         let to = CLLocation(latitude: other.latitude, longitude: other.longitude)
         return from.distance(from: to)
     }
+
+    var accessibilityTimestamp: String {
+        timestamp.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    var accessibilityCoordinateSummary: String {
+        String(format: "Latitude %.4f, longitude %.4f", latitude, longitude)
+    }
+
+    var accessibilityAccuracySummary: String {
+        String(format: "Accuracy about %.0f meters", horizontalAccuracy)
+    }
+
+    var accessibilityValue: String {
+        var parts = [
+            accessibilityTimestamp,
+            accessibilityCoordinateSummary,
+            accessibilityAccuracySummary
+        ]
+
+        if let speed {
+            parts.append(String(format: "Speed %.1f meters per second", speed))
+        }
+
+        if isOutlier {
+            parts.append("Marked as an outlier")
+        }
+
+        return parts.joined(separator: ". ")
+    }
 }
 
 extension LocationPoint {

--- a/IsoMe/Models/Visit.swift
+++ b/IsoMe/Models/Visit.swift
@@ -83,6 +83,28 @@ final class Visit {
     var isCurrentVisit: Bool {
         departedAt == nil
     }
+
+    var accessibilityLabel: String {
+        if isCurrentVisit {
+            return "Current visit at \(displayName)"
+        }
+        return "Visit at \(displayName)"
+    }
+
+    var accessibilityValue: String {
+        var parts: [String] = [formattedTimeRange, formattedDuration]
+
+        if let address, !address.isEmpty, address != displayName {
+            parts.append(address)
+        }
+
+        parts.append(String(format: "Latitude %.4f, longitude %.4f", latitude, longitude))
+        return parts.joined(separator: ". ")
+    }
+
+    var accessibilityHint: String {
+        "Opens visit details."
+    }
 }
 
 extension Visit {

--- a/IsoMe/ViewModels/LocationViewModel.swift
+++ b/IsoMe/ViewModels/LocationViewModel.swift
@@ -163,6 +163,29 @@ final class LocationViewModel {
         formatDistance(sessionDistanceTraveled)
     }
 
+    var sessionAccessibilitySummary: String {
+        let pointCount = sessionLocationPoints.count
+        guard pointCount > 0 else {
+            return "No active session path points."
+        }
+
+        var parts = [
+            "\(pointCount) \(pointCount == 1 ? "point" : "points")",
+            "Duration \(formattedSessionTrackingDuration)",
+            "Distance \(formattedSessionDistance)"
+        ]
+
+        if let first = sessionLocationPoints.first {
+            parts.append("Started \(first.accessibilityTimestamp)")
+        }
+
+        if let last = sessionLocationPoints.last, pointCount > 1 {
+            parts.append("Latest point \(last.accessibilityTimestamp)")
+        }
+
+        return parts.joined(separator: ". ")
+    }
+
     // Today's tracking stats (kept for other views)
     var todayTrackingDuration: TimeInterval {
         guard let first = todayLocationPoints.first,

--- a/IsoMe/Views/MapView.swift
+++ b/IsoMe/Views/MapView.swift
@@ -94,7 +94,10 @@ struct LocationMapView: View {
                     
                     if showSessionPath, let firstSessionPoint = activeSessionPoints.first {
                         Annotation("Session Start", coordinate: firstSessionPoint.coordinate) {
-                            StartMarker()
+                            StartMarker(
+                                accessibilityLabel: "Active session start",
+                                accessibilityValue: firstSessionPoint.accessibilityValue
+                            )
                         }
                     }
                     
@@ -102,7 +105,10 @@ struct LocationMapView: View {
                        let lastSessionPoint = activeSessionPoints.last,
                        activeSessionPoints.count > 1 {
                         Annotation("Current", coordinate: lastSessionPoint.coordinate) {
-                            CurrentLocationMarker()
+                            CurrentLocationMarker(
+                                accessibilityLabel: "Active session current location",
+                                accessibilityValue: lastSessionPoint.accessibilityValue
+                            )
                         }
                     }
                     
@@ -133,6 +139,7 @@ struct LocationMapView: View {
                                         Circle()
                                             .stroke(.white, lineWidth: 1.5)
                                     }
+                                    .accessibilityHidden(true)
                             }
                         }
                     }
@@ -156,6 +163,8 @@ struct LocationMapView: View {
                     MapCompass()
                     MapScaleView()
                 }
+                .accessibilityLabel("Location map")
+                .accessibilityValue(mapAccessibilitySummary)
                 .safeAreaInset(edge: .top, spacing: 0) {
                     if !discordPromoDismissed {
                         DiscordPromoBanner(onDismiss: dismissDiscordPromo)
@@ -304,6 +313,18 @@ struct LocationMapView: View {
             }
         }
     }
+
+    private var mapAccessibilitySummary: String {
+        var parts: [String] = []
+        parts.append("\(filteredVisits.count) \(filteredVisits.count == 1 ? "visit" : "visits")")
+        parts.append("\(filteredPoints.count) \(filteredPoints.count == 1 ? "path point" : "path points")")
+
+        if !activeSessionPoints.isEmpty {
+            parts.append("Active session: \(viewModel.sessionAccessibilitySummary)")
+        }
+
+        return parts.joined(separator: ". ")
+    }
 }
 
 // MARK: - Tracking Control Pills
@@ -326,12 +347,19 @@ struct MapTrackingControlPill: View {
                     }
                 } label: {
                     statusBlock
+                        .frame(minWidth: 44, minHeight: 44)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Session summary")
+                .accessibilityValue(viewModel.sessionAccessibilitySummary)
+                .accessibilityHint(isExpanded ? "Collapses session details." : "Expands session details.")
                 .transition(.opacity.combined(with: .move(edge: .trailing)))
 
                 if isExpanded {
                     statsBlock
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("Session details")
+                        .accessibilityValue(viewModel.sessionAccessibilitySummary)
                         .transition(.asymmetric(
                             insertion: .opacity.combined(with: .move(edge: .trailing)),
                             removal: .opacity.combined(with: .move(edge: .trailing))
@@ -374,6 +402,7 @@ struct MapTrackingControlPill: View {
                 .fill(isTracking ? TE.accent : TE.textMuted.opacity(0.35))
                 .frame(width: 7, height: 7)
                 .opacity(isTracking ? pulseOpacity : 1.0)
+                .accessibilityHidden(true)
                 .animation(
                     isTracking
                         ? .easeInOut(duration: 1.2).repeatForever(autoreverses: true)
@@ -408,6 +437,7 @@ struct MapTrackingControlPill: View {
             Rectangle()
                 .fill(Color.primary.opacity(0.15))
                 .frame(width: 1, height: 12)
+                .accessibilityHidden(true)
 
             Text("\(viewModel.sessionLocationPoints.count) PTS")
                 .font(TE.mono(.caption, weight: .medium))
@@ -442,8 +472,12 @@ struct MapTrackingControlPill: View {
                             y: 3
                         )
                 }
+                .frame(width: 44, height: 44)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(isTracking ? "Stop tracking" : "Start tracking")
+        .accessibilityValue(isTracking ? viewModel.sessionAccessibilitySummary : "Tracking is off.")
+        .accessibilityHint(isTracking ? "Stops the active session." : "Starts a new location tracking session.")
         .sensoryFeedback(.impact(flexibility: .solid), trigger: isTracking)
     }
 }
@@ -456,6 +490,7 @@ struct MapAutoOffPill: View {
             Image(systemName: "timer")
                 .font(.system(size: 10, weight: .medium))
                 .foregroundStyle(TE.textMuted)
+                .accessibilityHidden(true)
 
             Text("AUTO-OFF  \(formatTime(remaining))")
                 .font(TE.mono(.caption2, weight: .semibold))
@@ -480,6 +515,9 @@ struct MapAutoOffPill: View {
                 }
                 .shadow(color: .black.opacity(0.12), radius: 8, x: 0, y: 3)
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Tracking auto-off")
+        .accessibilityValue("Stops in \(spokenTime(remaining)).")
     }
 
     private func formatTime(_ interval: TimeInterval) -> String {
@@ -487,6 +525,15 @@ struct MapAutoOffPill: View {
         let minutes = (Int(interval) % 3600) / 60
         if hours > 0 { return "\(hours)H \(minutes)M" }
         return "\(minutes) MIN"
+    }
+
+    private func spokenTime(_ interval: TimeInterval) -> String {
+        let hours = Int(interval) / 3600
+        let minutes = (Int(interval) % 3600) / 60
+        if hours > 0 {
+            return "\(hours) \(hours == 1 ? "hour" : "hours") and \(minutes) \(minutes == 1 ? "minute" : "minutes")"
+        }
+        return "\(minutes) \(minutes == 1 ? "minute" : "minutes")"
     }
 }
 
@@ -500,17 +547,26 @@ struct VisitMarker: View {
                 Circle()
                     .fill(visit.isCurrentVisit ? .blue : .red)
                     .frame(width: isSelected ? 36 : 28, height: isSelected ? 36 : 28)
+                    .accessibilityHidden(true)
 
                 Image(systemName: "mappin")
                     .font(.system(size: isSelected ? 18 : 14))
                     .foregroundStyle(.white)
+                    .accessibilityHidden(true)
             }
 
             Triangle()
                 .fill(visit.isCurrentVisit ? .blue : .red)
                 .frame(width: 10, height: 8)
+                .accessibilityHidden(true)
         }
+        .frame(minWidth: 44, minHeight: 44)
         .animation(.spring(duration: 0.2), value: isSelected)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(visit.accessibilityLabel)
+        .accessibilityValue(visit.accessibilityValue)
+        .accessibilityHint(visit.accessibilityHint)
+        .accessibilityAddTraits(.isButton)
     }
 }
 
@@ -532,32 +588,41 @@ struct PathStartMarker: View {
     @State private var showingTooltip = false
     
     var body: some View {
-        VStack(spacing: 2) {
-            if showingTooltip {
-                Text(timestamp.formatted(date: .abbreviated, time: .shortened))
-                    .font(.caption2)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(.ultraThinMaterial, in: Capsule())
-                    .transition(.scale.combined(with: .opacity))
-            }
-            
-            ZStack {
-                Circle()
-                    .fill(.green)
-                    .frame(width: 28, height: 28)
-                
-                Image(systemName: "flag.fill")
-                    .font(.system(size: 14))
-                    .foregroundStyle(.white)
-            }
-            .shadow(color: .green.opacity(0.4), radius: 4, y: 2)
-        }
-        .onTapGesture {
+        Button {
             withAnimation(.spring(duration: 0.2)) {
                 showingTooltip.toggle()
             }
+        } label: {
+            VStack(spacing: 2) {
+                if showingTooltip {
+                    Text(timestamp.formatted(date: .abbreviated, time: .shortened))
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .transition(.scale.combined(with: .opacity))
+                        .accessibilityHidden(true)
+                }
+
+                ZStack {
+                    Circle()
+                        .fill(.green)
+                        .frame(width: 28, height: 28)
+                        .accessibilityHidden(true)
+
+                    Image(systemName: "flag.fill")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.white)
+                        .accessibilityHidden(true)
+                }
+                .shadow(color: .green.opacity(0.4), radius: 4, y: 2)
+            }
+            .frame(minWidth: 44, minHeight: 44)
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Path start")
+        .accessibilityValue(timestamp.formatted(date: .abbreviated, time: .shortened))
+        .accessibilityHint(showingTooltip ? "Hides the start time." : "Shows the start time.")
     }
 }
 
@@ -566,32 +631,41 @@ struct PathEndMarker: View {
     @State private var showingTooltip = false
     
     var body: some View {
-        VStack(spacing: 2) {
-            if showingTooltip {
-                Text(timestamp.formatted(date: .abbreviated, time: .shortened))
-                    .font(.caption2)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(.ultraThinMaterial, in: Capsule())
-                    .transition(.scale.combined(with: .opacity))
-            }
-            
-            ZStack {
-                Circle()
-                    .fill(.red)
-                    .frame(width: 28, height: 28)
-                
-                Image(systemName: "flag.checkered")
-                    .font(.system(size: 14))
-                    .foregroundStyle(.white)
-            }
-            .shadow(color: .red.opacity(0.4), radius: 4, y: 2)
-        }
-        .onTapGesture {
+        Button {
             withAnimation(.spring(duration: 0.2)) {
                 showingTooltip.toggle()
             }
+        } label: {
+            VStack(spacing: 2) {
+                if showingTooltip {
+                    Text(timestamp.formatted(date: .abbreviated, time: .shortened))
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .transition(.scale.combined(with: .opacity))
+                        .accessibilityHidden(true)
+                }
+
+                ZStack {
+                    Circle()
+                        .fill(.red)
+                        .frame(width: 28, height: 28)
+                        .accessibilityHidden(true)
+
+                    Image(systemName: "flag.checkered")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.white)
+                        .accessibilityHidden(true)
+                }
+                .shadow(color: .red.opacity(0.4), radius: 4, y: 2)
+            }
+            .frame(minWidth: 44, minHeight: 44)
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Path end")
+        .accessibilityValue(timestamp.formatted(date: .abbreviated, time: .shortened))
+        .accessibilityHint(showingTooltip ? "Hides the end time." : "Shows the end time.")
     }
 }
 
@@ -800,6 +874,15 @@ enum MapDatePreset: CaseIterable, Hashable {
         }
     }
 
+    var accessibilityLabel: String {
+        switch self {
+        case .today: return "Today"
+        case .sevenDays: return "Last 7 days"
+        case .thirtyDays: return "Last 30 days"
+        case .all: return "All time"
+        }
+    }
+
     func range(referenceDate: Date = Date()) -> ClosedRange<Date> {
         let calendar = Calendar.current
         switch self {
@@ -824,7 +907,7 @@ struct FilterBarToggle: View {
             Image(systemName: isOpen ? "xmark" : "slider.horizontal.3")
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(isOpen ? Color.white : Color.primary.opacity(0.75))
-                .frame(width: 42, height: 42)
+                .frame(width: 44, height: 44)
                 .background {
                     Circle()
                         .fill(isOpen ? AnyShapeStyle(TE.accent) : AnyShapeStyle(.ultraThinMaterial))
@@ -844,6 +927,8 @@ struct FilterBarToggle: View {
                 .contentTransition(.symbolEffect(.replace))
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(isOpen ? "Close map filters" : "Open map filters")
+        .accessibilityHint(isOpen ? "Hides date, layer, and fit controls." : "Shows date, layer, and fit controls.")
         .sensoryFeedback(.impact(flexibility: .soft), trigger: isOpen)
     }
 }
@@ -867,6 +952,7 @@ struct QuickFilterBar: View {
                 ForEach(MapDatePreset.allCases, id: \.self) { preset in
                     PresetPill(
                         label: preset.label,
+                        accessibilityLabel: preset.accessibilityLabel,
                         isActive: activePreset == preset
                     ) {
                         onSelectPreset(preset)
@@ -876,6 +962,7 @@ struct QuickFilterBar: View {
                 PresetPill(
                     label: "Custom",
                     icon: "calendar",
+                    accessibilityLabel: "Custom date range",
                     isActive: activePreset == nil
                 ) {
                     onSelectCustom()
@@ -883,12 +970,12 @@ struct QuickFilterBar: View {
 
                 PillSeparator()
 
-                LayerToggleButton(systemImage: "mappin.circle.fill", isOn: $showVisitMarkers)
-                LayerToggleButton(systemImage: "point.topleft.down.to.point.bottomright.curvepath", isOn: $showTravelPath)
-                LayerToggleButton(systemImage: "smallcircle.filled.circle", isOn: $showPointMarkers)
-                LayerToggleButton(systemImage: "flag.fill", isOn: $showStartEndMarkers)
+                LayerToggleButton(systemImage: "mappin.circle.fill", label: "Visit markers", isOn: $showVisitMarkers)
+                LayerToggleButton(systemImage: "point.topleft.down.to.point.bottomright.curvepath", label: "Travel path", isOn: $showTravelPath)
+                LayerToggleButton(systemImage: "smallcircle.filled.circle", label: "Point markers", isOn: $showPointMarkers)
+                LayerToggleButton(systemImage: "flag.fill", label: "Start and end markers", isOn: $showStartEndMarkers)
                 if hasSessionPoints {
-                    LayerToggleButton(systemImage: "waveform.path.ecg", isOn: $showSessionPath)
+                    LayerToggleButton(systemImage: "waveform.path.ecg", label: "Active session path", isOn: $showSessionPath)
                 }
 
                 PillSeparator()
@@ -923,6 +1010,7 @@ struct QuickFilterBar: View {
 struct PresetPill: View {
     let label: String
     var icon: String? = nil
+    var accessibilityLabel: String? = nil
     let isActive: Bool
     let action: () -> Void
 
@@ -932,6 +1020,7 @@ struct PresetPill: View {
                 if let icon = icon {
                     Image(systemName: icon)
                         .font(.system(size: 11, weight: .medium))
+                        .accessibilityHidden(true)
                 }
                 Text(label)
                     .font(.system(size: 13, weight: .semibold))
@@ -939,17 +1028,22 @@ struct PresetPill: View {
             .foregroundStyle(isActive ? Color.white : Color.primary)
             .padding(.horizontal, 12)
             .padding(.vertical, 7)
+            .frame(minHeight: 44)
             .background {
                 Capsule()
                     .fill(isActive ? TE.accent : Color.clear)
             }
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel ?? label)
+        .accessibilityValue(isActive ? "Selected" : "Not selected")
+        .accessibilityHint("Filters the map date range.")
     }
 }
 
 struct LayerToggleButton: View {
     let systemImage: String
+    let label: String
     @Binding var isOn: Bool
 
     var body: some View {
@@ -960,7 +1054,7 @@ struct LayerToggleButton: View {
         } label: {
             Image(systemName: systemImage)
                 .font(.system(size: 13, weight: .semibold))
-                .frame(width: 32, height: 32)
+                .frame(width: 44, height: 44)
                 .foregroundStyle(isOn ? Color.white : Color.primary.opacity(0.55))
                 .background {
                     Circle()
@@ -968,6 +1062,9 @@ struct LayerToggleButton: View {
                 }
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityValue(isOn ? "Shown" : "Hidden")
+        .accessibilityHint("Toggles this map layer.")
     }
 }
 
@@ -977,6 +1074,7 @@ struct PillSeparator: View {
             .fill(Color.primary.opacity(0.12))
             .frame(width: 1, height: 20)
             .padding(.horizontal, 2)
+            .accessibilityHidden(true)
     }
 }
 
@@ -1001,9 +1099,11 @@ struct FitMenuButton: View {
         } label: {
             Image(systemName: "scope")
                 .font(.system(size: 13, weight: .semibold))
-                .frame(width: 32, height: 32)
+                .frame(width: 44, height: 44)
                 .foregroundStyle(Color.primary.opacity(0.7))
         }
+        .accessibilityLabel("Fit map")
+        .accessibilityHint("Shows options for zooming the map to available content.")
     }
 }
 

--- a/IsoMe/Views/SessionPathMapView.swift
+++ b/IsoMe/Views/SessionPathMapView.swift
@@ -26,14 +26,20 @@ struct SessionPathMapView: View {
             // Start marker (first point)
             if let firstPoint = points.first {
                 Annotation("Start", coordinate: firstPoint.coordinate) {
-                    StartMarker()
+                    StartMarker(
+                        accessibilityLabel: "Session path start",
+                        accessibilityValue: firstPoint.accessibilityValue
+                    )
                 }
             }
             
             // End/Current marker (last point)
             if let lastPoint = points.last, points.count > 1 {
                 Annotation("Current", coordinate: lastPoint.coordinate) {
-                    CurrentLocationMarker()
+                    CurrentLocationMarker(
+                        accessibilityLabel: "Session path current location",
+                        accessibilityValue: lastPoint.accessibilityValue
+                    )
                 }
             }
             
@@ -43,6 +49,7 @@ struct SessionPathMapView: View {
                     Circle()
                         .fill(.blue.opacity(0.6))
                         .frame(width: 6, height: 6)
+                        .accessibilityHidden(true)
                 }
             }
         }
@@ -56,6 +63,8 @@ struct SessionPathMapView: View {
         .onAppear {
             updateCameraPosition()
         }
+        .accessibilityLabel("Session path map")
+        .accessibilityValue(sessionAccessibilitySummary)
     }
     
     /// Returns intermediate points (every 10th point, excluding first and last)
@@ -82,26 +91,69 @@ struct SessionPathMapView: View {
             cameraPosition = .region(region)
         }
     }
+
+    private var sessionAccessibilitySummary: String {
+        guard let first = points.first else {
+            return "No path points."
+        }
+
+        var parts = ["\(points.count) \(points.count == 1 ? "point" : "points")"]
+        parts.append("Started \(first.accessibilityTimestamp)")
+
+        if let last = points.last, points.count > 1 {
+            parts.append("Ended \(last.accessibilityTimestamp)")
+            parts.append("Distance \(formattedDistance(totalDistance))")
+        }
+
+        return parts.joined(separator: ". ")
+    }
+
+    private var totalDistance: Double {
+        guard points.count > 1 else { return 0 }
+        var distance: Double = 0
+        for index in 1..<points.count {
+            distance += points[index - 1].distance(to: points[index])
+        }
+        return distance
+    }
+
+    private func formattedDistance(_ meters: Double) -> String {
+        if meters >= 1_000 {
+            return String(format: "%.1f kilometers", meters / 1_000)
+        }
+        return String(format: "%.0f meters", meters)
+    }
 }
 
 // MARK: - Marker Views
 
 struct StartMarker: View {
+    var accessibilityLabel = "Path start"
+    var accessibilityValue = ""
+
     var body: some View {
         ZStack {
             Circle()
                 .fill(.green)
                 .frame(width: 24, height: 24)
+                .accessibilityHidden(true)
             
             Image(systemName: "flag.fill")
                 .font(.system(size: 12))
                 .foregroundStyle(.white)
+                .accessibilityHidden(true)
         }
+        .frame(width: 44, height: 44)
         .shadow(color: .green.opacity(0.3), radius: 4, y: 2)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(accessibilityValue)
     }
 }
 
 struct CurrentLocationMarker: View {
+    var accessibilityLabel = "Current location"
+    var accessibilityValue = ""
     @State private var isPulsing = false
     
     var body: some View {
@@ -112,15 +164,19 @@ struct CurrentLocationMarker: View {
                 .frame(width: 32, height: 32)
                 .scaleEffect(isPulsing ? 1.5 : 1.0)
                 .opacity(isPulsing ? 0 : 0.5)
+                .accessibilityHidden(true)
             
             Circle()
                 .fill(.blue)
                 .frame(width: 20, height: 20)
+                .accessibilityHidden(true)
             
             Circle()
                 .fill(.white)
                 .frame(width: 8, height: 8)
+                .accessibilityHidden(true)
         }
+        .frame(width: 44, height: 44)
         .shadow(color: .blue.opacity(0.3), radius: 4, y: 2)
         .onAppear {
             withAnimation(
@@ -130,6 +186,9 @@ struct CurrentLocationMarker: View {
                 isPulsing = true
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(accessibilityValue)
     }
 }
 

--- a/IsoMe/Views/VisitDetailView.swift
+++ b/IsoMe/Views/VisitDetailView.swift
@@ -67,6 +67,8 @@ struct VisitDetailView: View {
         }
         .frame(height: 200)
         .clipShape(RoundedRectangle(cornerRadius: 12))
+        .accessibilityLabel("Visit map")
+        .accessibilityValue("\(visit.accessibilityLabel). \(visit.accessibilityValue)")
     }
 
     private var locationInfoSection: some View {
@@ -87,6 +89,7 @@ struct VisitDetailView: View {
                         .background(.blue)
                         .foregroundStyle(.white)
                         .clipShape(Capsule())
+                        .accessibilityLabel("Current visit")
                 }
             }
 
@@ -122,6 +125,7 @@ struct VisitDetailView: View {
 
                 Image(systemName: "arrow.right")
                     .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
 
                 Spacer()
 
@@ -187,11 +191,15 @@ struct VisitDetailView: View {
             } label: {
                 HStack {
                     Image(systemName: "map")
+                        .accessibilityHidden(true)
                     Text("Open in Maps")
                 }
                 .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)
+            .accessibilityLabel("Open visit in Maps")
+            .accessibilityValue(visit.displayName)
+            .accessibilityHint("Opens this location in Apple Maps.")
 
             // Delete
             Button(role: .destructive) {
@@ -199,12 +207,14 @@ struct VisitDetailView: View {
             } label: {
                 HStack {
                     Image(systemName: "trash")
+                        .accessibilityHidden(true)
                     Text("Delete Visit")
                 }
                 .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)
             .tint(.red)
+            .accessibilityHint("Deletes this visit after confirmation.")
         }
     }
 


### PR DESCRIPTION
Fixes ISO-216

Implemented by Symphony agent automation.

## Issue

https://linear.app/isotech/issue/ISO-216/accessibility-add-voiceover-labelsvalues-for-map-annotations-and

## Simulator QA

Report: `.symphony/qa-report.md`
Artifact directory: `.symphony/qa-artifacts`

Screenshots: 4
Videos: 1
Other artifacts: 3

### .symphony/qa-artifacts/01-initial-map.png

![.symphony/qa-artifacts/01-initial-map.png](https://imghost.isolated.tech/fa26e08e.png)

### .symphony/qa-artifacts/02-active-session-route.png

![.symphony/qa-artifacts/02-active-session-route.png](https://imghost.isolated.tech/cfb5b6a5.png)

### .symphony/qa-artifacts/03-seeded-visit-marker.png

![.symphony/qa-artifacts/03-seeded-visit-marker.png](https://imghost.isolated.tech/f2a9de2a.png)

### .symphony/qa-artifacts/04-visit-detail.png

![.symphony/qa-artifacts/04-visit-detail.png](https://imghost.isolated.tech/5838bae0.png)

- other: `.symphony/qa-artifacts/accessibility-audit.txt`
- other: `.symphony/qa-artifacts/filters-accessibility-tree.json`
- video: [.symphony/qa-artifacts/iso-216-map-session-visit.mp4](https://imghost.isolated.tech/8d0640fb.mp4)
- other: `.symphony/qa-artifacts/visit-detail-accessibility-tree.json`

<details>
<summary>QA report</summary>

# ISO-216 QA Report

## Result

Pass.

The implementation adds VoiceOver-facing labels, values, hints, semantic buttons, decorative-element hiding, and 44 pt hit targets across the map, active session path, filter controls, visit markers, and visit detail map surfaces. I confirmed the changed behavior by code inspection, simulator build/run, simulator location updates, seeded simulator-only visit data, screenshots, video, and accessibility-tree inspection.

## Simulator

- Device: `ISO-216-QA`
- UDID: `C495F3C2-96AA-447B-A7E3-4B99348E4A3F`
- Runtime: iOS 26.3
- App bundle: `com.bontecou.isome`
- Build command: `xcodebuild -project IsoMe.xcodeproj -scheme IsoMe -configuration Debug -destination id=C495F3C2-96AA-447B-A7E3-4B99348E4A3F -derivedDataPath .symphony/DerivedData build`
- Build result: succeeded

## Mocked Data Setup

- Used only the dedicated simulator.
- Launched with debug arguments: `--seed-screenshot-data -hasCompletedOnboarding YES -allowNetworkGeocoding NO --default-tab=0`.
- Granted simulator location permission with `simctl privacy`.
- Fed deterministic local route points using `simctl location set` around San Francisco Civic Center.
- Added one simulator-only SwiftData visit fixture directly to the app sandbox store:
  - Name: `QA Civic Center Visit`
  - Address: `San Francisco Civic Center, San Francisco, CA`
  - Notes: `Simulator-only QA fixture`
- No production APIs, production auth, StoreKit purchases, Apple Account flows, or real user data were used.

## Steps Performed

1. Inspected the changed files:
   - `IsoMe/Models/LocationPoint.swift`
   - `IsoMe/Models/Visit.swift`
   - `IsoMe/ViewModels/LocationViewModel.swift`
   - `IsoMe/Views/MapView.swift`
   - `IsoMe/Views/SessionPathMapView.swift`
   - `IsoMe/Views/VisitDetailView.swift`
2. Confirmed new model/view-model spoken summaries:
   - Location point timestamp, coordinate, accuracy, speed, and outlier value strings.
   - Visit label/value/hint strings with time range, duration, address, and coordinates.
   - Active session point count, duration, distance, start, and latest-point summary.
3. Built and installed the app on the dedicated simulator.
4. Started tracking through the semantic `Start tracking` button.
5. Simulated route points and confirmed the map showed a session line, start marker, and current marker.
6. Seeded a local visit and confirmed the marker appeared and was exposed in the accessibility tree as `Visit at QA Civic Center Visit`.
7. Opened map filters and confirmed accessible controls for presets and layers, including `Visit markers`, `Travel path`, `Point markers`, and `Start and end markers`.
8. Opened the visit marker and confirmed the visit detail sheet displayed the seeded visit details.
9. Ran the simulator accessibility audit. It reported `0 critical` issues and generic `missing_traits` warnings for several standard SwiftUI/button/container elements.

## Evidence

- `01-initial-map.png`
- `02-active-session-route.png`
- `03-seeded-visit-marker.png`
- `04-visit-detail.png`
- `iso-216-map-session-visit.mp4`
- `filters-accessibility-tree.json`
- `visit-detail-accessibility-tree.json`
- `accessibility-audit.txt`

## Accessibility Findings

- Map/session controls are discoverable as named controls in the accessibility tree: `Session summary`, `Stop tracking`, `Open map filters`, `Path start`, `Path end`.
- Visit marker is discoverable as `Visit at QA Civic Center Visit`.
- Filter controls expose clear labels for date presets and map layers.
- Code inspection confirms decorative circles/icons/separators are hidden with `accessibilityHidden(true)`.
- Code inspection confirms map annotations and session path markers expose `accessibilityValue` summaries even where the simulator tree mapper only printed labels.
- Code inspection confirms interactive controls use `Button` and 44 pt frames where this ticket changed the UI.

## Limitations

- I could not perform a true manual VoiceOver audio/focus pass because this automated environment does not expose interactive VoiceOver speech output. I used simulator accessibility-tree inspection and code inspection to validate spoken labels/values/hints.
- The automated audit emitted generic `missing_traits` warnings for standard SwiftUI `Button`, app, tab bar, and MapKit elements despite the relevant controls being typed as buttons and labeled. There were no critical accessibility findings.

</details>

## Notes for reviewer

- Review generated changes carefully before merge.
- Verify tests/builds relevant to this repository.

- QA screenshots/videos are uploaded externally and embedded/linked above.
