### PR TITLE
ISO-157: [Testing Audit][iso.me][P0] Add GitHub Actions xcodebuild test gate

### DIFF
--- a/.github/workflows/xcodebuild-tests.yml
+++ b/.github/workflows/xcodebuild-tests.yml
@@ -1,0 +1,68 @@
+name: xcodebuild tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: xcodebuild-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: IsoMe XCTest
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Resolve iPhone simulator
+        id: simulator
+        run: |
+          set -euo pipefail
+
+          SIMULATOR_UDID=$(xcrun simctl list devices available -j | jq -r '
+            [.devices
+              | to_entries[]
+              | select(.key | contains("iOS"))
+              | .value[]
+              | select(.isAvailable == true and (.name | startswith("iPhone")))]
+            | .[0].udid // empty
+          ')
+
+          if [[ -z "$SIMULATOR_UDID" ]]; then
+            echo "::error::No available iPhone simulator found on this runner."
+            xcrun simctl list devices available
+            exit 1
+          fi
+
+          echo "destination=platform=iOS Simulator,id=$SIMULATOR_UDID" >> "$GITHUB_OUTPUT"
+          echo "Using simulator: $SIMULATOR_UDID"
+
+      - name: Run IsoMe tests
+        run: |
+          set -euo pipefail
+          rm -rf TestResults
+          mkdir -p TestResults
+
+          xcodebuild test \
+            -project IsoMe.xcodeproj \
+            -scheme IsoMe \
+            -destination "${{ steps.simulator.outputs.destination }}" \
+            -resultBundlePath TestResults/IsoMe.xcresult
+
+      - name: Upload xcresult on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: IsoMe.xcresult
+          path: TestResults/IsoMe.xcresult
+          if-no-files-found: ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,22 @@ The app, widget, and watch app share data via an App Group. Update the App Group
 3. ⌘R to build and run.
 4. On first launch the app requests **Location (Always)** and **Motion & Fitness** permissions — both are required to exercise visit detection and auto-start.
 
+### Run tests
+
+Pull requests run the shared `IsoMe` scheme's XCTest suite in GitHub Actions. To run the same gate locally against the first available iPhone simulator:
+
+```bash
+SIMULATOR_UDID=$(xcrun simctl list devices available -j | jq -r \
+  '[.devices | to_entries[] | select(.key | contains("iOS")) | .value[] | select(.isAvailable == true and (.name | startswith("iPhone")))] | .[0].udid')
+
+xcodebuild test \
+  -project IsoMe.xcodeproj \
+  -scheme IsoMe \
+  -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
+```
+
+The current tests use isolated in-memory or system test state where possible. Tests that touch `UserDefaults` clean up their keys in `setUp`/`tearDown`, and Keychain tests write only to test-specific account names.
+
 ## Testing on TestFlight
 
 If you have a paid Apple Developer account and want to dogfood your fork via TestFlight:


### PR DESCRIPTION
Fixes ISO-157

Implemented by Symphony agent automation.

## Issue

https://linear.app/isotech/issue/ISO-157/testing-auditisomep0-add-github-actions-xcodebuild-test-gate

## Simulator QA

Report: `.symphony/qa-report.md`
Artifact directory: `.symphony/qa-artifacts`

Screenshots: 2
Videos: 1
Other artifacts: 3

### .symphony/qa-artifacts/01-dedicated-simulator-booted.png

![.symphony/qa-artifacts/01-dedicated-simulator-booted.png](https://imghost.isolated.tech/7877cd3d.png)

### .symphony/qa-artifacts/02-after-xcodebuild-test.png

![.symphony/qa-artifacts/02-after-xcodebuild-test.png](https://imghost.isolated.tech/d8dd0fe3.png)

- other: `.symphony/qa-artifacts/simulator-udid.txt`
- other: `.symphony/qa-artifacts/xcodebuild-test-exit-code.txt`
- video: [.symphony/qa-artifacts/xcodebuild-test-run.mp4](https://imghost.isolated.tech/ace7618b.mp4)
- other: `.symphony/qa-artifacts/xcodebuild-test-summary.txt`

<details>
<summary>QA report</summary>

# QA Report: ISO-157

## Result

PASS

## Implementation Inspected

- Added `.github/workflows/xcodebuild-tests.yml`.
- Workflow runs on `pull_request` and `workflow_dispatch`.
- Workflow resolves an available iPhone simulator via `xcrun simctl list devices available -j` and `jq`.
- Workflow runs `xcodebuild test -project IsoMe.xcodeproj -scheme IsoMe -destination "$destination"` and uploads `TestResults/IsoMe.xcresult` only on failure.
- Added `CONTRIBUTING.md` documentation for the local test command and test isolation strategy.

## Simulator / Tooling

- Simulator: `ISO-157-QA-iPhone-17`
- Runtime: iOS 26.3
- UDID: `A97E5E22-D4D9-47C9-A42C-876B9FEAFF1F`
- Xcode: 26.3, build 17C529
- Linear CLI: 2.0.0

## Mocked Data Setup

- Used the existing XCTest suite only.
- No production APIs, production auth, StoreKit, Apple Account, purchase, Settings, or sign-in flows were invoked.
- Test coverage used deterministic local/system test state. The documented strategy notes UserDefaults cleanup in `setUp`/`tearDown` and test-specific Keychain account names.

## Steps Performed

1. Inspected `git status`, `git diff`, the new GitHub Actions workflow, `CONTRIBUTING.md`, and the shared `IsoMe` scheme.
2. Created and booted a dedicated iPhone simulator with explicit UDID `A97E5E22-D4D9-47C9-A42C-876B9FEAFF1F`.
3. Captured a pre-test simulator screenshot.
4. Started simulator screen recording.
5. Ran:

```bash
xcodebuild test \
  -project IsoMe.xcodeproj \
  -scheme IsoMe \
  -destination "platform=iOS Simulator,id=A97E5E22-D4D9-47C9-A42C-876B9FEAFF1F" \
  -derivedDataPath .symphony/DerivedData \
  -resultBundlePath .symphony/TestResults/IsoMe.xcresult
```

6. Captured a post-test simulator screenshot.
7. Verified Linear metadata with `linear issue view ISO-157`.

## Test Result

- `xcodebuild test` exit code: 0
- XCTest result: `Executed 32 tests, with 0 failures (0 unexpected)`
- Xcode result: `** TEST SUCCEEDED **`

## Linear Metadata Check

- Project: `iso.me`
- Milestone: `P0 — Gates & Release Blockers`
- Parent: `ISO-143`

## Evidence Files

- `01-dedicated-simulator-booted.png`
- `02-after-xcodebuild-test.png`
- `xcodebuild-test-run.mp4`
- `simulator-udid.txt`
- `xcodebuild-test-exit-code.txt`
- `xcodebuild-test-summary.txt`

## Limitations / Follow-Up

- GitHub Actions itself was not executed remotely from this QA session; validation covered workflow contents and the equivalent local `xcodebuild test` gate on a dedicated simulator.
- The local run emitted existing CoreData recovery and asset catalog warnings, but the app launched and all tests passed. No XCTest regression was observed.

</details>

## Notes for reviewer

- Review generated changes carefully before merge.
- Verify tests/builds relevant to this repository.

- QA screenshots/videos are uploaded externally and embedded/linked above.
