### PR TITLE
ISO-158: [Testing Audit][iso.me][P0] Add seven-format export round-trip tests

### DIFF
--- a/IsoMe.xcodeproj/project.pbxproj
+++ b/IsoMe.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		A4000004212F000100000004 /* IsoMeWatchWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = A4000000212F000000000000 /* IsoMeWatchWidgetExtension.appex */; platformFilter = watchos; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		BC063EB88C436E8BF576E318 /* StoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2C2BFF043232B2FF2E0BED /* StoreManager.swift */; };
 		CB0AF0C284FF821E6D718E7E /* LocationManagerTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A0A8C8D0C96D0243E02089 /* LocationManagerTrackingTests.swift */; };
+		D5E7A1580000000000000158 /* ExportRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E7A1580000000000000058 /* ExportRoundTripTests.swift */; };
 		DC2E3601C25B2712AD33AE98 /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59397DEAA02FEF6A5B6FA476 /* PaywallView.swift */; };
 		E1000001212F000100000001 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000001212F000000000001 /* AppInfo.swift */; };
 		E1000002212F000100000002 /* LogManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000002212F000000000002 /* LogManager.swift */; };
@@ -147,6 +148,7 @@
 		F1000001212F000000000001 /* FilenameTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilenameTemplate.swift; sourceTree = "<group>"; };
 		5F000002212F000000000001 /* DailyExportScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyExportScheduler.swift; sourceTree = "<group>"; };
 		76A0A8C8D0C96D0243E02089 /* LocationManagerTrackingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocationManagerTrackingTests.swift; sourceTree = "<group>"; };
+		D5E7A1580000000000000058 /* ExportRoundTripTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExportRoundTripTests.swift; sourceTree = "<group>"; };
 		7A2C2BFF043232B2FF2E0BED /* StoreManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StoreManager.swift; sourceTree = "<group>"; };
 		E1000001212F000000000001 /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		E1000002212F000000000002 /* LogManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogManager.swift; sourceTree = "<group>"; };
@@ -435,6 +437,7 @@
 		AD8A47404A1FA6D94EF61780 /* IsoMeTests */ = {
 			isa = PBXGroup;
 			children = (
+				D5E7A1580000000000000058 /* ExportRoundTripTests.swift */,
 				76A0A8C8D0C96D0243E02089 /* LocationManagerTrackingTests.swift */,
 				F1FE2A7AF0F63FFD8AE276F3 /* SharedLocationDataTests.swift */,
 				8F7F078A773745EF8CE42F37 /* WebhookManagerTests.swift */,
@@ -720,6 +723,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5E7A1580000000000000158 /* ExportRoundTripTests.swift in Sources */,
 				CB0AF0C284FF821E6D718E7E /* LocationManagerTrackingTests.swift in Sources */,
 				F3601C83F23A13A26444AD47 /* SharedLocationDataTests.swift in Sources */,
 				A1178698C9FA49F18135BC6B /* WebhookManagerTests.swift in Sources */,

--- a/IsoMeTests/ExportRoundTripTests.swift
+++ b/IsoMeTests/ExportRoundTripTests.swift
@@ -1,0 +1,661 @@
+import XCTest
+@testable import IsoMe
+
+final class ExportRoundTripTests: XCTestCase {
+    private struct ExportCase {
+        let name: String
+        let format: ExportFormat
+        let expectedFileExtension: String
+    }
+
+    fileprivate struct NormalizedVisit: Equatable {
+        let latitude: Double
+        let longitude: Double
+        let arrivedAt: Date?
+        let departedAt: Date?
+        let locationName: String?
+        let address: String?
+        let notes: String?
+    }
+
+    fileprivate struct NormalizedPoint: Equatable {
+        let latitude: Double
+        let longitude: Double
+        let timestamp: Date?
+        let altitude: Double?
+        let speed: Double?
+        let horizontalAccuracy: Double?
+        let isOutlier: Bool?
+    }
+
+    private let cases: [ExportCase] = [
+        ExportCase(name: "JSON", format: .json, expectedFileExtension: "json"),
+        ExportCase(name: "CSV", format: .csv, expectedFileExtension: "csv"),
+        ExportCase(name: "Markdown", format: .markdown, expectedFileExtension: "md"),
+        ExportCase(name: "GeoJSON", format: .geojson, expectedFileExtension: "geojson"),
+        ExportCase(name: "GPX", format: .gpx, expectedFileExtension: "gpx"),
+        ExportCase(name: "OwnTracks", format: .owntracks, expectedFileExtension: "json"),
+        ExportCase(name: "Overland", format: .overland, expectedFileExtension: "json")
+    ]
+
+    fileprivate static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private var baseDate: Date {
+        Self.iso8601.date(from: "2026-05-10T14:15:30.000Z")!
+    }
+
+    func testAllExportFormatsRoundTripRepresentativeDataWithoutSchemaDrift() throws {
+        let visits = representativeVisits()
+        let points = representativePoints()
+
+        for testCase in cases {
+            var options = ExportOptions()
+            options.dataKind = .all
+            options.format = testCase.format
+
+            let rendered = try ExportService.render(
+                visits: visits,
+                points: points,
+                options: options,
+                filenamePattern: "{kind}-{format}.{ext}"
+            )
+
+            XCTAssertTrue(
+                rendered.fileName.hasSuffix(".\(testCase.expectedFileExtension)"),
+                "\(testCase.name) emitted unexpected filename: \(rendered.fileName)"
+            )
+
+            let roundTripped = try parseRenderedExport(rendered.data, format: testCase.format)
+
+            if testCase.format.isPointsOnly {
+                XCTAssertTrue(roundTripped.visits.isEmpty, "\(testCase.name) should not emit visits")
+            } else {
+                assertVisits(roundTripped.visits, match: visits, formatName: testCase.name)
+            }
+
+            assertPoints(roundTripped.points, match: points, formatName: testCase.name)
+        }
+    }
+
+    private func representativeVisits() -> [Visit] {
+        [
+            Visit(
+                latitude: 37.776502,
+                longitude: -122.424098,
+                arrivedAt: baseDate,
+                departedAt: baseDate.addingTimeInterval(45 * 60),
+                locationName: "Civic Cafe",
+                address: "1 Market St, San Francisco, CA",
+                notes: "Coffee, sync, receipts"
+            ),
+            Visit(
+                latitude: 37.786901,
+                longitude: -122.399101,
+                arrivedAt: baseDate.addingTimeInterval(2 * 60 * 60),
+                departedAt: baseDate.addingTimeInterval(3 * 60 * 60 + 15 * 60),
+                locationName: "Pier Office",
+                address: "Pier 3, San Francisco, CA",
+                notes: "Quarterly planning"
+            )
+        ]
+    }
+
+    private func representativePoints() -> [LocationPoint] {
+        [
+            LocationPoint(
+                latitude: 37.776600,
+                longitude: -122.424000,
+                timestamp: baseDate.addingTimeInterval(5 * 60),
+                altitude: 12.4,
+                speed: 1.8,
+                horizontalAccuracy: 4.5,
+                isOutlier: false
+            ),
+            LocationPoint(
+                latitude: 37.781200,
+                longitude: -122.415700,
+                timestamp: baseDate.addingTimeInterval(15 * 60),
+                altitude: 18.9,
+                speed: 3.2,
+                horizontalAccuracy: 6.0,
+                isOutlier: true
+            )
+        ]
+    }
+
+    private func parseRenderedExport(
+        _ data: Data,
+        format: ExportFormat
+    ) throws -> (visits: [NormalizedVisit], points: [NormalizedPoint]) {
+        switch format {
+        case .json:
+            return try parseCombinedJSON(data)
+        case .csv:
+            return try parseCombinedCSV(data)
+        case .markdown:
+            return try parseCombinedMarkdown(data)
+        case .geojson:
+            return try parseGeoJSON(data)
+        case .gpx:
+            return try parseGPX(data)
+        case .owntracks:
+            return try parseOwnTracks(data)
+        case .overland:
+            return try parseOverland(data)
+        }
+    }
+
+    private func parseCombinedJSON(_ data: Data) throws -> (visits: [NormalizedVisit], points: [NormalizedPoint]) {
+        let object = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(
+            Set(object.keys),
+            ["dateRange", "exportDate", "points", "totalPoints", "totalVisits", "visits"]
+        )
+
+        let visitsJSON = try XCTUnwrap(object["visits"] as? [[String: Any]])
+        let pointsJSON = try XCTUnwrap(object["points"] as? [[String: Any]])
+        XCTAssertEqual(try XCTUnwrap(object["totalVisits"] as? Int), visitsJSON.count)
+        XCTAssertEqual(try XCTUnwrap(object["totalPoints"] as? Int), pointsJSON.count)
+
+        return (
+            visits: visitsJSON.map(parseJSONVisit),
+            points: pointsJSON.map(parseJSONPoint)
+        )
+    }
+
+    private func parseOwnTracks(_ data: Data) throws -> (visits: [NormalizedVisit], points: [NormalizedPoint]) {
+        let messages = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+
+        let points = try messages.map { message -> NormalizedPoint in
+            XCTAssertEqual(Set(message.keys), ["_type", "acc", "alt", "lat", "lon", "tid", "tst", "vel"])
+            XCTAssertEqual(try XCTUnwrap(message["_type"] as? String), "location")
+            XCTAssertEqual(try XCTUnwrap(message["tid"] as? String), "IM")
+
+            return NormalizedPoint(
+                latitude: try XCTUnwrap(message["lat"] as? Double),
+                longitude: try XCTUnwrap(message["lon"] as? Double),
+                timestamp: Date(timeIntervalSince1970: TimeInterval(try XCTUnwrap(message["tst"] as? Int))),
+                altitude: Double(try XCTUnwrap(message["alt"] as? Int)),
+                speed: Double(try XCTUnwrap(message["vel"] as? Int)) / 3.6,
+                horizontalAccuracy: Double(try XCTUnwrap(message["acc"] as? Int)),
+                isOutlier: nil
+            )
+        }
+
+        return (visits: [], points: points)
+    }
+
+    private func parseOverland(_ data: Data) throws -> (visits: [NormalizedVisit], points: [NormalizedPoint]) {
+        let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(Set(payload.keys), ["current", "locations"])
+
+        let locations = try XCTUnwrap(payload["locations"] as? [[String: Any]])
+        _ = try XCTUnwrap(payload["current"] as? [String: Any])
+
+        let points = try locations.map { feature -> NormalizedPoint in
+            XCTAssertEqual(Set(feature.keys), ["geometry", "properties", "type"])
+            XCTAssertEqual(try XCTUnwrap(feature["type"] as? String), "Feature")
+
+            let geometry = try XCTUnwrap(feature["geometry"] as? [String: Any])
+            XCTAssertEqual(Set(geometry.keys), ["coordinates", "type"])
+            XCTAssertEqual(try XCTUnwrap(geometry["type"] as? String), "Point")
+            let coordinates = try XCTUnwrap(geometry["coordinates"] as? [Double])
+
+            let properties = try XCTUnwrap(feature["properties"] as? [String: Any])
+            XCTAssertEqual(Set(properties.keys), ["altitude", "device_id", "horizontal_accuracy", "speed", "timestamp"])
+            XCTAssertEqual(try XCTUnwrap(properties["device_id"] as? String), "isome")
+
+            return NormalizedPoint(
+                latitude: coordinates[1],
+                longitude: coordinates[0],
+                timestamp: Self.iso8601.date(from: try XCTUnwrap(properties["timestamp"] as? String)),
+                altitude: properties["altitude"] as? Double,
+                speed: properties["speed"] as? Double,
+                horizontalAccuracy: properties["horizontal_accuracy"] as? Double,
+                isOutlier: nil
+            )
+        }
+
+        return (visits: [], points: points)
+    }
+
+    private func parseGeoJSON(_ data: Data) throws -> (visits: [NormalizedVisit], points: [NormalizedPoint]) {
+        let collection = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(Set(collection.keys), ["exportDate", "features", "generator", "type"])
+        XCTAssertEqual(try XCTUnwrap(collection["type"] as? String), "FeatureCollection")
+        XCTAssertEqual(try XCTUnwrap(collection["generator"] as? String), "iso.me")
+
+        let features = try XCTUnwrap(collection["features"] as? [[String: Any]])
+        var visits: [NormalizedVisit] = []
+        var points: [NormalizedPoint] = []
+
+        for feature in features {
+            XCTAssertEqual(Set(feature.keys), ["geometry", "properties", "type"])
+            XCTAssertEqual(try XCTUnwrap(feature["type"] as? String), "Feature")
+            let geometry = try XCTUnwrap(feature["geometry"] as? [String: Any])
+            XCTAssertEqual(Set(geometry.keys), ["coordinates", "type"])
+            XCTAssertEqual(try XCTUnwrap(geometry["type"] as? String), "Point")
+            let coordinates = try XCTUnwrap(geometry["coordinates"] as? [Double])
+            let properties = try XCTUnwrap(feature["properties"] as? [String: Any])
+
+            switch try XCTUnwrap(properties["kind"] as? String) {
+            case "visit":
+                XCTAssertEqual(Set(properties.keys), ["address", "arrivedAt", "departedAt", "durationMinutes", "kind", "locationName", "notes"])
+                visits.append(NormalizedVisit(
+                    latitude: coordinates[1],
+                    longitude: coordinates[0],
+                    arrivedAt: Self.iso8601.date(from: try XCTUnwrap(properties["arrivedAt"] as? String)),
+                    departedAt: Self.iso8601.date(from: try XCTUnwrap(properties["departedAt"] as? String)),
+                    locationName: properties["locationName"] as? String,
+                    address: properties["address"] as? String,
+                    notes: properties["notes"] as? String
+                ))
+            case "point":
+                XCTAssertEqual(Set(properties.keys), ["altitude", "horizontalAccuracy", "isOutlier", "kind", "speed", "timestamp", "timestampUnix"])
+                var altitude: Double? = properties["altitude"] as? Double
+                if altitude == nil, coordinates.count == 3 { altitude = coordinates[2] }
+                points.append(NormalizedPoint(
+                    latitude: coordinates[1],
+                    longitude: coordinates[0],
+                    timestamp: Self.iso8601.date(from: try XCTUnwrap(properties["timestamp"] as? String)),
+                    altitude: altitude,
+                    speed: properties["speed"] as? Double,
+                    horizontalAccuracy: properties["horizontalAccuracy"] as? Double,
+                    isOutlier: properties["isOutlier"] as? Bool
+                ))
+            default:
+                XCTFail("Unexpected GeoJSON kind: \(properties)")
+            }
+        }
+
+        return (visits: visits, points: points)
+    }
+
+    private func parseCombinedCSV(_ data: Data) throws -> (visits: [NormalizedVisit], points: [NormalizedPoint]) {
+        let rows = parseCSVRows(try XCTUnwrap(String(data: data, encoding: .utf8)))
+        guard let visitHeaderIndex = rows.firstIndex(where: { $0.first == "arrived_at" }),
+              let pointsHeaderIndex = rows.firstIndex(where: { $0.first == "timestamp" }) else {
+            XCTFail("Combined CSV missing visit or point sections")
+            return ([], [])
+        }
+
+        let visitHeaders = rows[visitHeaderIndex]
+        let pointHeaders = rows[pointsHeaderIndex]
+        XCTAssertEqual(visitHeaders, ["arrived_at", "departed_at", "duration_minutes", "latitude", "longitude", "location_name", "address", "notes"])
+        XCTAssertEqual(pointHeaders, ["timestamp", "timestamp_unix", "latitude", "longitude", "altitude", "speed", "horizontal_accuracy", "is_outlier"])
+
+        let visitRows = rows[(visitHeaderIndex + 1)..<pointsHeaderIndex]
+            .filter { !$0.isEmpty && !$0[0].isEmpty && !$0[0].hasPrefix("#") }
+        let pointRows = rows[(pointsHeaderIndex + 1)..<rows.endIndex]
+            .filter { !$0.isEmpty && !$0[0].isEmpty && !$0[0].hasPrefix("#") }
+
+        return (
+            visits: visitRows.map { row in
+                NormalizedVisit(
+                    latitude: Double(row[3])!,
+                    longitude: Double(row[4])!,
+                    arrivedAt: Self.iso8601.date(from: row[0]),
+                    departedAt: Self.iso8601.date(from: row[1]),
+                    locationName: row[5],
+                    address: row[6],
+                    notes: row[7]
+                )
+            },
+            points: pointRows.map { row in
+                NormalizedPoint(
+                    latitude: Double(row[2])!,
+                    longitude: Double(row[3])!,
+                    timestamp: Self.iso8601.date(from: row[0]),
+                    altitude: Double(row[4]),
+                    speed: Double(row[5]),
+                    horizontalAccuracy: Double(row[6]),
+                    isOutlier: row[7] == "true"
+                )
+            }
+        )
+    }
+
+    private func parseCombinedMarkdown(_ data: Data) throws -> (visits: [NormalizedVisit], points: [NormalizedPoint]) {
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(text.contains("# iso.me Complete Export"))
+        XCTAssertTrue(text.contains("# Visits"))
+        XCTAssertTrue(text.contains("# Location Points"))
+
+        let visitSection = try markdownSection(named: "# Visits", in: text)
+        let pointSection = try markdownSection(named: "# Location Points", in: text)
+        let visitRows = markdownTableRows(in: visitSection)
+        let pointRows = markdownTableRows(in: pointSection)
+
+        XCTAssertEqual(visitRows.first, "| Arrived | Departed | Duration | Lat | Lon | Location | Address | Notes |")
+        XCTAssertEqual(pointRows.first, "| Time | Lat | Lon | Speed | Altitude | Accuracy | Outlier |")
+
+        return (
+            visits: visitRows.dropFirst().map { row in
+                let cells = markdownCells(row)
+                return NormalizedVisit(
+                    latitude: Double(cells[3])!,
+                    longitude: Double(cells[4])!,
+                    arrivedAt: nil,
+                    departedAt: nil,
+                    locationName: cells[5],
+                    address: cells[6],
+                    notes: cells[7]
+                )
+            },
+            points: pointRows.dropFirst().map { row in
+                let cells = markdownCells(row)
+                return NormalizedPoint(
+                    latitude: Double(cells[1])!,
+                    longitude: Double(cells[2])!,
+                    timestamp: nil,
+                    altitude: numericPrefix(cells[4]),
+                    speed: numericPrefix(cells[3]),
+                    horizontalAccuracy: numericPrefix(cells[5]),
+                    isOutlier: cells[6] == "yes"
+                )
+            }
+        )
+    }
+
+    private func parseGPX(_ data: Data) throws -> (visits: [NormalizedVisit], points: [NormalizedPoint]) {
+        let parser = GPXRoundTripParser()
+        let xmlParser = XMLParser(data: data)
+        xmlParser.delegate = parser
+        XCTAssertTrue(xmlParser.parse(), xmlParser.parserError?.localizedDescription ?? "GPX parse failed")
+
+        XCTAssertEqual(parser.rootAttributes["version"], "1.1")
+        XCTAssertEqual(parser.rootAttributes["creator"], "iso.me")
+        XCTAssertEqual(parser.rootAttributes["xmlns"], "http://www.topografix.com/GPX/1/1")
+        XCTAssertEqual(parser.rootAttributes["xmlns:isome"], "https://isome.isolated.tech/gpx/1.0")
+
+        return (visits: parser.visits, points: parser.points)
+    }
+
+    private func parseJSONVisit(_ dict: [String: Any]) -> NormalizedVisit {
+        XCTAssertEqual(Set(dict.keys), ["address", "arrivedAt", "departedAt", "durationMinutes", "latitude", "locationName", "longitude", "notes"])
+        return NormalizedVisit(
+            latitude: dict["latitude"] as! Double,
+            longitude: dict["longitude"] as! Double,
+            arrivedAt: Self.iso8601.date(from: dict["arrivedAt"] as! String),
+            departedAt: Self.iso8601.date(from: dict["departedAt"] as! String),
+            locationName: dict["locationName"] as? String,
+            address: dict["address"] as? String,
+            notes: dict["notes"] as? String
+        )
+    }
+
+    private func parseJSONPoint(_ dict: [String: Any]) -> NormalizedPoint {
+        XCTAssertEqual(Set(dict.keys), ["altitude", "horizontalAccuracy", "isOutlier", "latitude", "longitude", "speed", "timestamp", "timestampUnix"])
+        return NormalizedPoint(
+            latitude: dict["latitude"] as! Double,
+            longitude: dict["longitude"] as! Double,
+            timestamp: Self.iso8601.date(from: dict["timestamp"] as! String),
+            altitude: dict["altitude"] as? Double,
+            speed: dict["speed"] as? Double,
+            horizontalAccuracy: dict["horizontalAccuracy"] as? Double,
+            isOutlier: dict["isOutlier"] as? Bool
+        )
+    }
+
+    private func assertVisits(_ actual: [NormalizedVisit], match expected: [Visit], formatName: String) {
+        XCTAssertEqual(actual.count, expected.count, "\(formatName) visit count drifted")
+        for (index, pair) in zip(actual, expected).enumerated() {
+            XCTAssertEqual(pair.0.latitude, pair.1.latitude, accuracy: 0.000001, "\(formatName) visit \(index) latitude")
+            XCTAssertEqual(pair.0.longitude, pair.1.longitude, accuracy: 0.000001, "\(formatName) visit \(index) longitude")
+            if let arrivedAt = pair.0.arrivedAt {
+                XCTAssertEqual(arrivedAt.timeIntervalSince1970, pair.1.arrivedAt.timeIntervalSince1970, accuracy: 0.001, "\(formatName) visit \(index) arrival")
+            }
+            if let departedAt = pair.0.departedAt, let expectedDeparture = pair.1.departedAt {
+                XCTAssertEqual(departedAt.timeIntervalSince1970, expectedDeparture.timeIntervalSince1970, accuracy: 0.001, "\(formatName) visit \(index) departure")
+            }
+            XCTAssertEqual(pair.0.locationName, pair.1.locationName, "\(formatName) visit \(index) location")
+            XCTAssertEqual(pair.0.address, pair.1.address, "\(formatName) visit \(index) address")
+            XCTAssertEqual(pair.0.notes, pair.1.notes, "\(formatName) visit \(index) notes")
+        }
+    }
+
+    private func assertPoints(_ actual: [NormalizedPoint], match expected: [LocationPoint], formatName: String) {
+        XCTAssertEqual(actual.count, expected.count, "\(formatName) point count drifted")
+        for (index, pair) in zip(actual, expected).enumerated() {
+            XCTAssertEqual(pair.0.latitude, pair.1.latitude, accuracy: 0.000001, "\(formatName) point \(index) latitude")
+            XCTAssertEqual(pair.0.longitude, pair.1.longitude, accuracy: 0.000001, "\(formatName) point \(index) longitude")
+            if let timestamp = pair.0.timestamp {
+                XCTAssertEqual(timestamp.timeIntervalSince1970, pair.1.timestamp.timeIntervalSince1970, accuracy: 1.0, "\(formatName) point \(index) timestamp")
+            }
+            XCTAssertEqual(pair.0.altitude ?? 0, pair.1.altitude ?? 0, accuracy: 0.51, "\(formatName) point \(index) altitude")
+            XCTAssertEqual(pair.0.speed ?? 0, pair.1.speed ?? 0, accuracy: 0.15, "\(formatName) point \(index) speed")
+            XCTAssertEqual(pair.0.horizontalAccuracy ?? 0, pair.1.horizontalAccuracy, accuracy: 0.51, "\(formatName) point \(index) accuracy")
+            if let isOutlier = pair.0.isOutlier {
+                XCTAssertEqual(isOutlier, pair.1.isOutlier, "\(formatName) point \(index) outlier flag")
+            }
+        }
+    }
+
+    private func markdownCells(_ row: String) -> [String] {
+        row.split(separator: "|", omittingEmptySubsequences: false)
+            .dropFirst()
+            .dropLast()
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    private func markdownSection(named heading: String, in text: String) throws -> String {
+        let components = text.components(separatedBy: heading)
+        guard components.count >= 2 else {
+            XCTFail("Missing Markdown section \(heading)")
+            return ""
+        }
+        let tail = components[1]
+        if let nextSection = tail.range(of: "\n# ") {
+            return String(tail[..<nextSection.lowerBound])
+        }
+        return tail
+    }
+
+    private func markdownTableRows(in section: String) -> [String] {
+        section.components(separatedBy: .newlines)
+            .filter { $0.hasPrefix("| ") && !$0.contains("------") }
+    }
+
+    private func numericPrefix(_ value: String) -> Double? {
+        Double(value.components(separatedBy: " ").first ?? "")
+    }
+
+    private func parseCSVRows(_ content: String) -> [[String]] {
+        var rows: [[String]] = []
+        var currentField = ""
+        var currentRow: [String] = []
+        var inQuotes = false
+        let chars = Array(content)
+        var i = 0
+
+        while i < chars.count {
+            let char = chars[i]
+
+            if inQuotes {
+                if char == "\"" {
+                    if i + 1 < chars.count && chars[i + 1] == "\"" {
+                        currentField.append("\"")
+                        i += 2
+                    } else {
+                        inQuotes = false
+                        i += 1
+                    }
+                } else {
+                    currentField.append(char)
+                    i += 1
+                }
+            } else {
+                if char == "\"" {
+                    inQuotes = true
+                    i += 1
+                } else if char == "," {
+                    currentRow.append(currentField)
+                    currentField = ""
+                    i += 1
+                } else if char == "\n" {
+                    currentRow.append(currentField)
+                    if !currentRow.allSatisfy({ $0.isEmpty }) {
+                        rows.append(currentRow)
+                    }
+                    currentField = ""
+                    currentRow = []
+                    i += 1
+                } else if char == "\r" {
+                    i += 1
+                } else {
+                    currentField.append(char)
+                    i += 1
+                }
+            }
+        }
+
+        if !currentField.isEmpty || !currentRow.isEmpty {
+            currentRow.append(currentField)
+            rows.append(currentRow)
+        }
+
+        return rows
+    }
+}
+
+private final class GPXRoundTripParser: NSObject, XMLParserDelegate {
+    private(set) var rootAttributes: [String: String] = [:]
+    private(set) var visits: [ExportRoundTripTests.NormalizedVisit] = []
+    private(set) var points: [ExportRoundTripTests.NormalizedPoint] = []
+
+    private var elementStack: [String] = []
+    private var textBuffer = ""
+    private var currentVisit: CurrentVisit?
+    private var currentPoint: CurrentPoint?
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        elementStack.append(elementName)
+        textBuffer = ""
+
+        if elementName == "gpx" {
+            rootAttributes = attributeDict
+        } else if elementName == "wpt" {
+            currentVisit = CurrentVisit(
+                latitude: Double(attributeDict["lat"] ?? "")!,
+                longitude: Double(attributeDict["lon"] ?? "")!
+            )
+        } else if elementName == "trkpt" {
+            currentPoint = CurrentPoint(
+                latitude: Double(attributeDict["lat"] ?? "")!,
+                longitude: Double(attributeDict["lon"] ?? "")!
+            )
+        }
+    }
+
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        textBuffer += string
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        let value = textBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if currentVisit != nil {
+            switch elementName {
+            case "time":
+                currentVisit?.arrivedAt = ExportRoundTripTests.iso8601.date(from: value)
+            case "name":
+                currentVisit?.locationName = value
+            case "desc":
+                let parts = value.components(separatedBy: " — ")
+                currentVisit?.address = parts.first
+                currentVisit?.notes = parts.dropFirst().joined(separator: " — ")
+            case "isome:departedAt":
+                currentVisit?.departedAt = ExportRoundTripTests.iso8601.date(from: value)
+            default:
+                break
+            }
+        }
+
+        if currentPoint != nil {
+            switch elementName {
+            case "ele":
+                currentPoint?.altitude = Double(value)
+            case "time":
+                currentPoint?.timestamp = ExportRoundTripTests.iso8601.date(from: value)
+            case "isome:speed":
+                currentPoint?.speed = Double(value)
+            case "isome:horizontalAccuracy":
+                currentPoint?.horizontalAccuracy = Double(value)
+            case "isome:isOutlier":
+                currentPoint?.isOutlier = value == "true"
+            default:
+                break
+            }
+        }
+
+        if elementName == "wpt", let visit = currentVisit {
+            visits.append(visit.normalized)
+            currentVisit = nil
+        } else if elementName == "trkpt", let point = currentPoint {
+            points.append(point.normalized)
+            currentPoint = nil
+        }
+
+        _ = elementStack.popLast()
+        textBuffer = ""
+    }
+
+    private struct CurrentVisit {
+        let latitude: Double
+        let longitude: Double
+        var arrivedAt: Date?
+        var departedAt: Date?
+        var locationName: String?
+        var address: String?
+        var notes: String?
+
+        var normalized: ExportRoundTripTests.NormalizedVisit {
+            ExportRoundTripTests.NormalizedVisit(
+                latitude: latitude,
+                longitude: longitude,
+                arrivedAt: arrivedAt,
+                departedAt: departedAt,
+                locationName: locationName,
+                address: address,
+                notes: notes
+            )
+        }
+    }
+
+    private struct CurrentPoint {
+        let latitude: Double
+        let longitude: Double
+        var timestamp: Date?
+        var altitude: Double?
+        var speed: Double?
+        var horizontalAccuracy: Double?
+        var isOutlier: Bool?
+
+        var normalized: ExportRoundTripTests.NormalizedPoint {
+            ExportRoundTripTests.NormalizedPoint(
+                latitude: latitude,
+                longitude: longitude,
+                timestamp: timestamp,
+                altitude: altitude,
+                speed: speed,
+                horizontalAccuracy: horizontalAccuracy,
+                isOutlier: isOutlier
+            )
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ Shared/                            # Shared code (App Group data sync)
 4. Configure the App Group entitlement (`group.com.bontecou.isome`) for your team
 5. Build and run on a physical device (location features require real hardware)
 
+## Testing
+
+Run the app unit tests with:
+
+```bash
+xcodebuild test -project IsoMe.xcodeproj -scheme IsoMe -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+
+Export round-trip coverage lives in `IsoMeTests/ExportRoundTripTests.swift`. It uses inline representative visit and route-point fixtures, renders JSON, CSV, Markdown, GeoJSON, GPX, OwnTracks, and Overland through `ExportService.render`, then parses each payload back into normalized records while asserting the emitted schema keys. OwnTracks and Overland are points-only protocols, so their cases verify route points and explicitly assert that visits are not emitted.
+
 ### Required Permissions
 
 The app requests the following permissions at runtime:


### PR DESCRIPTION
Fixes ISO-158

Implemented by Symphony agent automation.

## Issue

https://linear.app/isotech/issue/ISO-158/testing-auditisomep0-add-seven-format-export-round-trip-tests

## Simulator QA

Report: `.symphony/qa-report.md`
Artifact directory: `.symphony/qa-artifacts`

Screenshots: 6
Videos: 1
Other artifacts: 1

- video: [.symphony/qa-artifacts/export-format-selector.mp4](https://imghost.isolated.tech/a9eeae96.mp4)
### .symphony/qa-artifacts/export-tab-after-alert.png

![.symphony/qa-artifacts/export-tab-after-alert.png](https://imghost.isolated.tech/8df20ae2.png)

### .symphony/qa-artifacts/export-tab-all-json.png

![.symphony/qa-artifacts/export-tab-all-json.png](https://imghost.isolated.tech/27aa1cdd.png)

### .symphony/qa-artifacts/export-tab-initial.png

![.symphony/qa-artifacts/export-tab-initial.png](https://imghost.isolated.tech/9057a302.png)

### .symphony/qa-artifacts/location-permission-alert-2.png

![.symphony/qa-artifacts/location-permission-alert-2.png](https://imghost.isolated.tech/4a7c7b50.png)

### .symphony/qa-artifacts/location-permission-alert.png

![.symphony/qa-artifacts/location-permission-alert.png](https://imghost.isolated.tech/d525211e.png)

### .symphony/qa-artifacts/onboarding-permissions.png

![.symphony/qa-artifacts/onboarding-permissions.png](https://imghost.isolated.tech/093ae1f4.png)

- other: `.symphony/qa-artifacts/xcodebuild-test.log`

<details>
<summary>QA report</summary>

# QA Report: ISO-158

## Result

PASS

## Simulator / Device

- Dedicated iOS Simulator: `ISO-158-QA`
- UDID: `19BDB981-8848-44FC-A5FC-CE14C65CC117`
- Runtime: iOS 26.3
- App bundle: `com.bontecou.isome`

## Mocked Data Setup

- Used deterministic inline fixtures in `IsoMeTests/ExportRoundTripTests.swift`.
- No production APIs, production auth, StoreKit purchase flow, Apple account flow, or real user data were used.
- The app was run as a Debug simulator build; `StoreManager` sets `isPurchased = true` under `DEBUG`, so export UI access did not invoke real StoreKit.
- Location permission prompts were dismissed with `Don't Allow`.

## Code / Feature Inspected

- New test file: `IsoMeTests/ExportRoundTripTests.swift`
- Project wiring: `IsoMe.xcodeproj/project.pbxproj`
- Documentation: `README.md` Testing section
- Export implementation checked around `ExportService.render`, combined JSON/CSV/Markdown, GeoJSON, GPX, OwnTracks, and Overland paths.

## Steps Performed

1. Inspected the git diff and confirmed the change adds a seven-format export round-trip XCTest plus README documentation.
2. Created and booted a dedicated simulator named `ISO-158-QA`.
3. Ran:

   ```bash
   xcodebuild test -project IsoMe.xcodeproj -scheme IsoMe -destination 'platform=iOS Simulator,id=19BDB981-8848-44FC-A5FC-CE14C65CC117' -derivedDataPath .symphony/DerivedData
   ```

4. Confirmed `ExportRoundTripTests.testAllExportFormatsRoundTripRepresentativeDataWithoutSchemaDrift` passed.
5. Confirmed the full `IsoMeTests` suite passed: 33 tests, 0 failures.
6. Installed and launched the Debug app on the dedicated simulator.
7. Completed onboarding without granting location permission.
8. Opened the Export tab and exercised the data-kind selector plus visible export format controls: JSON, CSV, Markdown, OwnTracks, Overland, and GPX.
9. Verified Linear metadata with `linear issue view ISO-158`: project `iso.me`, milestone `P0 — Gates & Release Blockers`, parent `ISO-143`.

## Evidence

- `xcodebuild-test.log`
- `export-format-selector.mp4`
- `export-tab-initial.png`
- `location-permission-alert.png`
- `location-permission-alert-2.png`
- `onboarding-permissions.png`
- `export-tab-after-alert.png`
- `export-tab-all-json.png`

All evidence files are under `.symphony/qa-artifacts`.

## Limitations / Follow-up

- The simulator app had no local trip/visit data, so UI export action showed `NOTHING TO EXPORT`; the end-to-end round-trip validation was performed through deterministic XCTest fixtures.
- The Export screen currently exposes JSON, CSV, Markdown, OwnTracks, Overland, and GPX controls in the visible format selector; GeoJSON coverage was validated by the new XCTest path rather than a UI button.
- CoreData emitted transient simulator setup log noise about creating the app group store directory, then recovered; tests completed successfully.

</details>

## Notes for reviewer

- Review generated changes carefully before merge.
- Verify tests/builds relevant to this repository.

- QA screenshots/videos are uploaded externally and embedded/linked above.
