### PR TITLE
ISO-159: [Testing Audit][iso.me][P0] Add webhook delivery, error, and retry tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,16 @@ Then upload the IPA to App Store Connect via Transporter.app or `xcrun altool`.
 - **Privacy by default** — no analytics, no telemetry, no network calls that ship user data off-device.
 - **Match existing patterns** — read the surrounding files before adding a new model, service, or view.
 
+## Tests
+
+Run the iOS unit tests from the command line with:
+
+```bash
+xcodebuild test -project IsoMe.xcodeproj -scheme IsoMe -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+
+`IsoMeTests/WebhookManagerTests.swift` uses a custom `URLProtocol` fixture to mock webhook HTTP responses. Queue responses with `MockWebhookURLProtocol.enqueue(statusCode:)`, inject the matching ephemeral `URLSession` into `WebhookManager`, and keep retry tests fast by passing a `sleep` closure that records requested backoff delays instead of waiting.
+
 ## Pull request workflow
 
 1. Fork the repo and create a feature branch off `main`.

--- a/IsoMe/Services/WebhookManager.swift
+++ b/IsoMe/Services/WebhookManager.swift
@@ -15,6 +15,19 @@ import SwiftData
 final class WebhookManager: ObservableObject {
     static let shared = WebhookManager()
 
+    struct RetryPolicy {
+        let maxAttempts: Int
+        let baseDelay: TimeInterval
+        let multiplier: Double
+
+        static let `default` = RetryPolicy(maxAttempts: 3, baseDelay: 1, multiplier: 2)
+
+        func delay(beforeAttempt attempt: Int) -> TimeInterval {
+            guard attempt > 1 else { return 0 }
+            return baseDelay * pow(multiplier, Double(attempt - 2))
+        }
+    }
+
     // MARK: - Auth types
 
     enum AuthType: String, CaseIterable, Identifiable {
@@ -95,12 +108,14 @@ final class WebhookManager: ObservableObject {
 
     // MARK: - Private
 
-    private let defaults = UserDefaults.standard
+    private let defaults: UserDefaults
     private var cancellables = Set<AnyCancellable>()
     private var flushTimer: Timer?
     private var pendingPoints: [LocationPoint] = []
     private weak var modelContainer: ModelContainer?
     private var urlSession: URLSession!
+    private let retryPolicy: RetryPolicy
+    private let sleep: (TimeInterval) async -> Void
     // Realtime cursor — nil means we haven't observed a tick yet. The first tick
     // arms the cursor without sending so we never bulk-resend the historical DB
     // after launch; subsequent ticks send everything strictly newer.
@@ -120,16 +135,26 @@ final class WebhookManager: ObservableObject {
     static func keychainAccount(_ k: KeychainKey) -> String { "webhook.\(k.rawValue)" }
     static func legacyDefaultsKey(_ k: KeychainKey) -> String { "webhook.\(k.rawValue)" }
 
-    private init() {
+    init(
+        defaults: UserDefaults = .standard,
+        urlSession: URLSession? = nil,
+        retryPolicy: RetryPolicy = .default,
+        sleep: @escaping (TimeInterval) async -> Void = { delay in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        }
+    ) {
+        self.defaults = defaults
+        self.retryPolicy = retryPolicy
+        self.sleep = sleep
         let d = defaults
         self.isEnabled = d.bool(forKey: Self.key(.enabled))
         self.urlString = d.string(forKey: Self.key(.url)) ?? ""
         self.format = Self.formatFromToken(d.string(forKey: Self.key(.format)))
         self.authType = AuthType(rawValue: d.string(forKey: Self.key(.authType)) ?? "") ?? .none
 
-        self.authKey = Self.loadCredential(.authKey, defaultValue: "api_key")
-        self.authValue = Self.loadCredential(.authValue, defaultValue: "")
-        self.authUsername = Self.loadCredential(.authUsername, defaultValue: "")
+        self.authKey = Self.loadCredential(.authKey, defaults: d, defaultValue: "api_key")
+        self.authValue = Self.loadCredential(.authValue, defaults: d, defaultValue: "")
+        self.authUsername = Self.loadCredential(.authUsername, defaults: d, defaultValue: "")
 
         self.sendMode = SendMode(rawValue: d.string(forKey: Self.key(.sendMode)) ?? "") ?? .realtime
         self.batchCount = d.object(forKey: Self.key(.batchCount)) as? Int ?? 10
@@ -137,10 +162,14 @@ final class WebhookManager: ObservableObject {
         self.lastSentAt = d.object(forKey: Self.key(.lastSentAt)) as? Date
         self.lastError = d.string(forKey: Self.key(.lastError))
 
-        let config = URLSessionConfiguration.ephemeral
-        config.timeoutIntervalForRequest = 30
-        config.timeoutIntervalForResource = 60
-        self.urlSession = URLSession(configuration: config)
+        if let urlSession {
+            self.urlSession = urlSession
+        } else {
+            let config = URLSessionConfiguration.ephemeral
+            config.timeoutIntervalForRequest = 30
+            config.timeoutIntervalForResource = 60
+            self.urlSession = URLSession(configuration: config)
+        }
 
         syncTimer()
     }
@@ -148,23 +177,29 @@ final class WebhookManager: ObservableObject {
     /// Read a credential from Keychain. If absent but a non-empty legacy
     /// UserDefaults value exists, migrate it into Keychain and clear the
     /// plaintext copy.
-    static func loadCredential(account: String, legacyKey: String, defaultValue: String) -> String {
+    static func loadCredential(
+        account: String,
+        legacyKey: String,
+        defaultValue: String,
+        defaults: UserDefaults = .standard
+    ) -> String {
         if let stored = keychainReadString(account: account) {
             return stored
         }
-        if let legacy = UserDefaults.standard.string(forKey: legacyKey), !legacy.isEmpty {
+        if let legacy = defaults.string(forKey: legacyKey), !legacy.isEmpty {
             keychainWriteString(legacy, account: account)
-            UserDefaults.standard.removeObject(forKey: legacyKey)
+            defaults.removeObject(forKey: legacyKey)
             return legacy
         }
         return defaultValue
     }
 
-    private static func loadCredential(_ key: KeychainKey, defaultValue: String) -> String {
+    private static func loadCredential(_ key: KeychainKey, defaults: UserDefaults, defaultValue: String) -> String {
         loadCredential(
             account: keychainAccount(key),
             legacyKey: legacyDefaultsKey(key),
-            defaultValue: defaultValue
+            defaultValue: defaultValue,
+            defaults: defaults
         )
     }
 
@@ -243,14 +278,12 @@ final class WebhookManager: ObservableObject {
 
                 switch sendMode {
                 case .batchCount:
-                    pendingPoints.append(latest)
-                    queuedPointCount = pendingPoints.count
+                    enqueuePendingPoint(latest)
                     if pendingPoints.count >= batchCount {
                         await flushBatch()
                     }
                 case .batchTime:
-                    pendingPoints.append(latest)
-                    queuedPointCount = pendingPoints.count
+                    enqueuePendingPoint(latest)
                 case .manual, .realtime:
                     break
                 }
@@ -273,6 +306,11 @@ final class WebhookManager: ObservableObject {
             queuedPointCount = pendingPoints.count
             recordError(error.localizedDescription)
         }
+    }
+
+    func enqueuePendingPoint(_ point: LocationPoint) {
+        pendingPoints.append(point)
+        queuedPointCount = pendingPoints.count
     }
 
     /// Send a manual export of all saved data.
@@ -338,7 +376,7 @@ final class WebhookManager: ObservableObject {
         request.setValue("iso.me/\(AppInfo.version)", forHTTPHeaderField: "User-Agent")
         applyAuth(to: &request)
 
-        let (_, response) = try await urlSession.data(for: request)
+        let (_, response) = try await sendRequestWithRetry(request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             throw WebhookError.httpError((response as? HTTPURLResponse)?.statusCode ?? 0)
@@ -348,6 +386,50 @@ final class WebhookManager: ObservableObject {
         defaults.set(lastSentAt, forKey: Self.key(.lastSentAt))
         lastError = nil
         defaults.removeObject(forKey: Self.key(.lastError))
+    }
+
+    private func sendRequestWithRetry(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        let attempts = max(1, retryPolicy.maxAttempts)
+
+        for attempt in 1...attempts {
+            if attempt > 1 {
+                await sleep(retryPolicy.delay(beforeAttempt: attempt))
+            }
+
+            do {
+                let result = try await urlSession.data(for: request)
+                guard let httpResponse = result.1 as? HTTPURLResponse else {
+                    throw WebhookError.httpError(0)
+                }
+                if (200...299).contains(httpResponse.statusCode) {
+                    return result
+                }
+                throw WebhookError.httpError(httpResponse.statusCode)
+            } catch {
+                guard attempt < attempts, Self.shouldRetry(error) else {
+                    throw error
+                }
+            }
+        }
+
+        throw WebhookError.httpError(0)
+    }
+
+    private static func shouldRetry(_ error: Error) -> Bool {
+        if error is URLError {
+            return true
+        }
+
+        guard let webhookError = error as? WebhookError else {
+            return false
+        }
+
+        switch webhookError {
+        case .httpError(let code):
+            return code == 0 || code == 408 || code == 429 || code >= 500
+        case .invalidURL, .unauthorized:
+            return false
+        }
     }
 
     // MARK: - URL building

--- a/IsoMeTests/WebhookManagerTests.swift
+++ b/IsoMeTests/WebhookManagerTests.swift
@@ -10,14 +10,23 @@ final class WebhookManagerTests: XCTestCase {
 
     private let testAccount = "webhook.tests.authValue"
     private let testLegacyKey = "webhook.tests.authValue"
+    private var defaults: UserDefaults!
+    private var defaultsSuiteName: String!
 
     override func setUp() {
         super.setUp()
+        defaultsSuiteName = "WebhookManagerTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)!
         WebhookManager.keychainWriteString("", account: testAccount)
         UserDefaults.standard.removeObject(forKey: testLegacyKey)
+        MockWebhookURLProtocol.reset()
     }
 
     override func tearDown() {
+        MockWebhookURLProtocol.reset()
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        defaults = nil
+        defaultsSuiteName = nil
         WebhookManager.keychainWriteString("", account: testAccount)
         UserDefaults.standard.removeObject(forKey: testLegacyKey)
         super.tearDown()
@@ -182,5 +191,190 @@ final class WebhookManagerTests: XCTestCase {
             masking: secret
         )
         XCTAssertEqual(scrubbed, "url contains *** in the query")
+    }
+
+    // MARK: - Delivery
+
+    func testFlushBatchPostsPayloadAndClearsQueueOnSuccess() async {
+        MockWebhookURLProtocol.enqueue(statusCode: 201)
+        let manager = makeWebhookManager(retryPolicy: .init(maxAttempts: 1, baseDelay: 0, multiplier: 1))
+        manager.urlString = "https://example.com/hooks/location"
+        manager.enqueuePendingPoint(makePoint(latitude: 10.1, longitude: -20.2))
+
+        await manager.flushBatch()
+
+        XCTAssertEqual(manager.queuedPointCount, 0)
+        XCTAssertNil(manager.lastError)
+        XCTAssertNotNil(manager.lastSentAt)
+        XCTAssertEqual(MockWebhookURLProtocol.requests.count, 1)
+        XCTAssertEqual(MockWebhookURLProtocol.requests.first?.httpMethod, "POST")
+        XCTAssertEqual(MockWebhookURLProtocol.requests.first?.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = String(data: MockWebhookURLProtocol.requestBodies.first ?? Data(), encoding: .utf8)
+        XCTAssertTrue(body?.contains("10.1") == true)
+        XCTAssertTrue(body?.contains("-20.2") == true)
+    }
+
+    func testFlushBatchRetainsQueueAndRecordsUserVisibleErrorOnNon2xx() async {
+        MockWebhookURLProtocol.enqueue(statusCode: 500)
+        let manager = makeWebhookManager(retryPolicy: .init(maxAttempts: 1, baseDelay: 0, multiplier: 1))
+        manager.urlString = "https://example.com/hooks/location"
+        manager.enqueuePendingPoint(makePoint())
+
+        await manager.flushBatch()
+
+        XCTAssertEqual(manager.queuedPointCount, 1)
+        XCTAssertEqual(manager.lastError, "Server returned HTTP 500")
+        XCTAssertNil(manager.lastSentAt)
+        XCTAssertEqual(defaults.string(forKey: "webhook.lastError"), "Server returned HTTP 500")
+        XCTAssertEqual(MockWebhookURLProtocol.requests.count, 1)
+    }
+
+    func testFlushBatchRetriesWithBackoffBeforeSuccess() async {
+        MockWebhookURLProtocol.enqueue(statusCode: 500)
+        MockWebhookURLProtocol.enqueue(statusCode: 502)
+        MockWebhookURLProtocol.enqueue(statusCode: 204)
+        var requestedDelays: [TimeInterval] = []
+        let manager = makeWebhookManager(
+            retryPolicy: .init(maxAttempts: 3, baseDelay: 0.25, multiplier: 3),
+            sleep: { requestedDelays.append($0) }
+        )
+        manager.urlString = "https://example.com/hooks/location"
+        manager.enqueuePendingPoint(makePoint())
+
+        await manager.flushBatch()
+
+        XCTAssertEqual(MockWebhookURLProtocol.requests.count, 3)
+        XCTAssertEqual(requestedDelays, [0.25, 0.75])
+        XCTAssertEqual(manager.queuedPointCount, 0)
+        XCTAssertNil(manager.lastError)
+        XCTAssertNotNil(manager.lastSentAt)
+    }
+
+    func testTestConnectionThrowsUnauthorizedFor401() async {
+        MockWebhookURLProtocol.enqueue(statusCode: 401)
+        let manager = makeWebhookManager(retryPolicy: .init(maxAttempts: 1, baseDelay: 0, multiplier: 1))
+        manager.urlString = "https://example.com/hooks/location"
+
+        do {
+            _ = try await manager.testConnection()
+            XCTFail("Expected unauthorized webhook error")
+        } catch {
+            XCTAssertEqual(error.localizedDescription, "Unauthorized (HTTP 401). Check your credentials.")
+        }
+    }
+
+    private func makeWebhookManager(
+        retryPolicy: WebhookManager.RetryPolicy,
+        sleep: @escaping (TimeInterval) async -> Void = { _ in }
+    ) -> WebhookManager {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockWebhookURLProtocol.self]
+        let session = URLSession(configuration: config)
+        return WebhookManager(
+            defaults: defaults,
+            urlSession: session,
+            retryPolicy: retryPolicy,
+            sleep: sleep
+        )
+    }
+
+    private func makePoint(latitude: Double = 37.7749, longitude: Double = -122.4194) -> LocationPoint {
+        LocationPoint(
+            latitude: latitude,
+            longitude: longitude,
+            timestamp: Date(timeIntervalSince1970: 1_776_000_000),
+            horizontalAccuracy: 5
+        )
+    }
+}
+
+private final class MockWebhookURLProtocol: URLProtocol {
+    private struct Response {
+        let statusCode: Int
+        let body: Data
+    }
+
+    private static let lock = NSLock()
+    private static var queuedResponses: [Response] = []
+    private(set) static var requests: [URLRequest] = []
+    private(set) static var requestBodies: [Data] = []
+
+    static func reset() {
+        lock.withLock {
+            queuedResponses = []
+            requests = []
+            requestBodies = []
+        }
+    }
+
+    static func enqueue(statusCode: Int, body: Data = Data()) {
+        lock.withLock {
+            queuedResponses.append(Response(statusCode: statusCode, body: body))
+        }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let next: Response? = Self.lock.withLock {
+            Self.requests.append(request)
+            Self.requestBodies.append(Self.bodyData(from: request))
+            return Self.queuedResponses.isEmpty ? nil : Self.queuedResponses.removeFirst()
+        }
+
+        guard let next else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: next.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: next.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func bodyData(from request: URLRequest) -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let count = stream.read(buffer, maxLength: bufferSize)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return body()
     }
 }


### PR DESCRIPTION
Fixes ISO-159

Implemented by Symphony agent automation.

## Issue

https://linear.app/isotech/issue/ISO-159/testing-auditisomep0-add-webhook-delivery-error-and-retry-tests

## Simulator QA

Report: `.symphony/qa-report.md`
Artifact directory: `.symphony/qa-artifacts`

Screenshots: 9
Videos: 1
Other artifacts: 0

### .symphony/qa-artifacts/01-export-webhook-section.png

![.symphony/qa-artifacts/01-export-webhook-section.png](https://imghost.isolated.tech/88941473.png)

### .symphony/qa-artifacts/02-system-location-alert.png

![.symphony/qa-artifacts/02-system-location-alert.png](https://imghost.isolated.tech/d1fb2e9b.png)

### .symphony/qa-artifacts/03-location-permission-during-onboarding.png

![.symphony/qa-artifacts/03-location-permission-during-onboarding.png](https://imghost.isolated.tech/7eeb2262.png)

### .symphony/qa-artifacts/04-webhook-settings-error-state.png

![.symphony/qa-artifacts/04-webhook-settings-error-state.png](https://imghost.isolated.tech/fbb28c82.png)

### .symphony/qa-artifacts/05-webhook-status-error-visible.png

![.symphony/qa-artifacts/05-webhook-status-error-visible.png](https://imghost.isolated.tech/49ce9f1d.png)

### .symphony/qa-artifacts/06-webhook-status-after-scroll.png

![.symphony/qa-artifacts/06-webhook-status-after-scroll.png](https://imghost.isolated.tech/c88afde4.png)

### .symphony/qa-artifacts/07-webhook-status-error-state.png

![.symphony/qa-artifacts/07-webhook-status-error-state.png](https://imghost.isolated.tech/464d9f68.png)

### .symphony/qa-artifacts/08-webhook-status-error-custom-scroll.png

![.symphony/qa-artifacts/08-webhook-status-error-custom-scroll.png](https://imghost.isolated.tech/23eff68e.png)

### .symphony/qa-artifacts/09-webhook-status-error-scroll-device-coords.png

![.symphony/qa-artifacts/09-webhook-status-error-scroll-device-coords.png](https://imghost.isolated.tech/e072ef04.png)

- video: [.symphony/qa-artifacts/webhook-ui-navigation.mp4](https://imghost.isolated.tech/9ebf4eb6.mp4)

<details>
<summary>QA report</summary>

# ISO-159 QA Report

## Result

PASS

## Simulator

- Device: ISO-159-QA-iPhone-17-Pro
- UDID: 083940C0-56A0-4E0A-8726-FB9CBB0253B8
- Runtime: iOS 26.3.1
- App bundle: com.bontecou.isome

## Implementation Inspected

- `IsoMe/Services/WebhookManager.swift`
  - Adds injectable `UserDefaults`, `URLSession`, retry policy, and async sleep hook.
  - Adds retry/backoff for webhook delivery via `sendRequestWithRetry`.
  - Keeps failed batches queued and persists sanitized `lastError`.
- `IsoMeTests/WebhookManagerTests.swift`
  - Adds deterministic `MockWebhookURLProtocol`.
  - Covers success delivery, HTTP 500 error state, retry/backoff before success, and 401 test-connection error handling.
- `CONTRIBUTING.md`
  - Documents the webhook test command and mock strategy.

## Mocked Data Setup

- No production APIs, auth, purchases, StoreKit flows, or real user data were used.
- Unit tests used local `MockWebhookURLProtocol` queued responses only.
- Simulator UI was seeded with local app defaults:
  - `webhook.enabled = true`
  - `webhook.url = https://example.invalid/webhook`
  - `webhook.lastError = Server returned HTTP 500`
- The endpoint is intentionally non-routable and was not invoked for QA evidence.

## Steps Performed

1. Reviewed the git diff for `CONTRIBUTING.md`, `WebhookManager.swift`, and `WebhookManagerTests.swift`.
2. Created and booted dedicated simulator `ISO-159-QA-iPhone-17-Pro`.
3. Ran focused webhook tests:
   - `xcodebuild test -project IsoMe.xcodeproj -scheme IsoMe -destination 'platform=iOS Simulator,id=083940C0-56A0-4E0A-8726-FB9CBB0253B8' -derivedDataPath .symphony/DerivedData -only-testing:IsoMeTests/WebhookManagerTests`
   - Result: passed, 21 tests, 0 failures.
4. Installed and launched the debug app on the dedicated simulator.
5. Dismissed location permission prompts with `Don't Allow`.
6. Navigated through onboarding to the Export tab and opened Webhook settings.
7. Verified the webhook UI showed enabled delivery, the local demo endpoint, and the user-visible `Server returned HTTP 500` error state.
8. Ran the full test target:
   - `xcodebuild test -project IsoMe.xcodeproj -scheme IsoMe -destination 'platform=iOS Simulator,id=083940C0-56A0-4E0A-8726-FB9CBB0253B8' -derivedDataPath .symphony/DerivedData`
   - Result: passed, 36 tests, 0 failures.

## Evidence

- `01-export-webhook-section.png`
- `02-system-location-alert.png`
- `03-location-permission-during-onboarding.png`
- `04-webhook-settings-error-state.png`
- `09-webhook-status-error-scroll-device-coords.png`
- `webhook-ui-navigation.mp4` (80.9 seconds)

## Limitations / Follow-up

- Linear metadata attachment to ISO-143 and the P0 milestone was not verified from this workspace because no Linear connector/session was available.
- The documented command in `CONTRIBUTING.md` names `iPhone 17`; local QA used an explicit simulator UDID to avoid ambiguity with multiple booted devices.

</details>

## Notes for reviewer

- Review generated changes carefully before merge.
- Verify tests/builds relevant to this repository.

- QA screenshots/videos are uploaded externally and embedded/linked above.
