### PR TITLE
Handle large location point datasets

### DIFF
--- a/IsoMe/Services/LocationManager.swift
+++ b/IsoMe/Services/LocationManager.swift
@@ -31,6 +31,7 @@ final class LocationManager: NSObject, ObservableObject {
 
     // Publisher for data changes (fires when new location points are saved)
     @Published var locationPointsSavedCount: Int = 0
+    @Published var latestSavedLocationPoint: LocationPoint?
 
     // Live Activity manager
     private let liveActivityManager = LiveActivityManager.shared
@@ -347,7 +348,10 @@ final class LocationManager: NSObject, ObservableObject {
             try context.save()
             pointBeforeLast = lastSavedPoint
             lastSavedPoint = point
-            // Notify observers that new data is available
+            // Notify observers that new data is available. Keep the latest point
+            // available so view models can update incrementally instead of
+            // re-fetching every stored point on each GPS update.
+            latestSavedLocationPoint = point
             locationPointsSavedCount += 1
             // Sync to watch widget (throttled by WidgetKit)
             syncDataToWatch()

--- a/IsoMe/ViewModels/LocationViewModel.swift
+++ b/IsoMe/ViewModels/LocationViewModel.swift
@@ -24,7 +24,8 @@ final class LocationViewModel {
     private var todayLocationPointsDay = Calendar.current.startOfDay(for: Date())
 
     // UI State
-    var mapDateRange: ClosedRange<Date> = Calendar.current.startOfDay(for: Date())...Date()
+    var activeMapPreset: MapDatePreset? = .today
+    var mapDateRange: ClosedRange<Date> = MapDatePreset.today.range()
     var showingExportSheet = false
     var showingClearConfirmation = false
     var exportError: String?
@@ -123,7 +124,34 @@ final class LocationViewModel {
         }
     }
 
-    func loadMapLocationPoints() {
+    func selectMapPreset(_ preset: MapDatePreset, referenceDate: Date = Date()) {
+        activeMapPreset = preset
+        mapDateRange = preset.range(referenceDate: referenceDate)
+        loadMapLocationPoints(referenceDate: referenceDate)
+    }
+
+    func setCustomMapDateRange(_ range: ClosedRange<Date>) {
+        activeMapPreset = nil
+        mapDateRange = range
+        loadMapLocationPoints()
+    }
+
+    @discardableResult
+    func refreshMapDateRangeIfUsingPreset(referenceDate: Date = Date()) -> Bool {
+        guard let preset = activeMapPreset else { return false }
+
+        let refreshedRange = preset.range(referenceDate: referenceDate)
+        let didChange = mapDateRange.lowerBound != refreshedRange.lowerBound ||
+            mapDateRange.upperBound != refreshedRange.upperBound
+        guard didChange else { return false }
+
+        mapDateRange = refreshedRange
+        return true
+    }
+
+    func loadMapLocationPoints(referenceDate: Date = Date()) {
+        refreshMapDateRangeIfUsingPreset(referenceDate: referenceDate)
+
         do {
             mapLocationPoints = try fetchLocationPoints(in: mapDateRange)
         } catch {
@@ -176,10 +204,18 @@ final class LocationViewModel {
             if !didCalendarDayChange {
                 loadTodayLocationPoints(referenceDate: referenceDate)
             }
-            loadMapLocationPoints()
+            loadMapLocationPoints(referenceDate: referenceDate)
             loadLocationPointCount()
             return
         }
+
+        let mapReferenceDate = max(referenceDate, point.timestamp)
+        let previousMapRange = mapDateRange
+        let didRefreshMapRange = refreshMapDateRangeIfUsingPreset(referenceDate: mapReferenceDate)
+        let shouldReloadMapCache = shouldReloadMapCacheAfterPresetRefresh(
+            from: previousMapRange,
+            didRefresh: didRefreshMapRange
+        )
 
         locationPointCount += 1
 
@@ -191,9 +227,19 @@ final class LocationViewModel {
             append(point, to: &todayLocationPoints)
         }
 
-        if mapDateRange.contains(point.timestamp) {
+        if shouldReloadMapCache {
+            loadMapLocationPoints(referenceDate: mapReferenceDate)
+        } else if mapDateRange.contains(point.timestamp) {
             append(point, to: &mapLocationPoints)
         }
+    }
+
+    private func shouldReloadMapCacheAfterPresetRefresh(
+        from previousRange: ClosedRange<Date>,
+        didRefresh: Bool
+    ) -> Bool {
+        guard didRefresh, activeMapPreset != nil else { return false }
+        return !Calendar.current.isDate(previousRange.lowerBound, inSameDayAs: mapDateRange.lowerBound)
     }
 
     private func append(_ point: LocationPoint, to points: inout [LocationPoint]) {

--- a/IsoMe/ViewModels/LocationViewModel.swift
+++ b/IsoMe/ViewModels/LocationViewModel.swift
@@ -21,6 +21,7 @@ final class LocationViewModel {
     var locationPointCount = 0
 
     private var allLocationPointsLoaded = false
+    private var todayLocationPointsDay = Calendar.current.startOfDay(for: Date())
 
     // UI State
     var mapDateRange: ClosedRange<Date> = Calendar.current.startOfDay(for: Date())...Date()
@@ -141,10 +142,11 @@ final class LocationViewModel {
         }
     }
 
-    func loadTodayLocationPoints() {
+    func loadTodayLocationPoints(referenceDate: Date = Date()) {
         let calendar = Calendar.current
-        let startOfDay = calendar.startOfDay(for: Date())
+        let startOfDay = calendar.startOfDay(for: referenceDate)
         let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)!
+        todayLocationPointsDay = startOfDay
 
         let predicate = #Predicate<LocationPoint> { point in
             point.timestamp >= startOfDay && point.timestamp < endOfDay
@@ -161,9 +163,19 @@ final class LocationViewModel {
         }
     }
 
-    private func appendLatestSavedLocationPoint() {
+    func appendLatestSavedLocationPoint(referenceDate: Date = Date()) {
+        let calendar = Calendar.current
+        let currentDay = calendar.startOfDay(for: referenceDate)
+        let didCalendarDayChange = todayLocationPointsDay != currentDay
+
+        if didCalendarDayChange {
+            loadTodayLocationPoints(referenceDate: referenceDate)
+        }
+
         guard let point = locationManager.latestSavedLocationPoint else {
-            loadTodayLocationPoints()
+            if !didCalendarDayChange {
+                loadTodayLocationPoints(referenceDate: referenceDate)
+            }
             loadMapLocationPoints()
             loadLocationPointCount()
             return
@@ -175,7 +187,7 @@ final class LocationViewModel {
             append(point, to: &locationPoints)
         }
 
-        if Calendar.current.isDate(point.timestamp, inSameDayAs: Date()) {
+        if calendar.isDate(point.timestamp, inSameDayAs: referenceDate) {
             append(point, to: &todayLocationPoints)
         }
 

--- a/IsoMe/ViewModels/LocationViewModel.swift
+++ b/IsoMe/ViewModels/LocationViewModel.swift
@@ -12,8 +12,15 @@ final class LocationViewModel {
     // Cached data
     var todayVisits: [Visit] = []
     var allVisits: [Visit] = []
+    /// Full point cache used by export flows. It is intentionally loaded on demand
+    /// because long trips can contain tens of thousands of points.
     var locationPoints: [LocationPoint] = []
+    /// Point cache for the currently selected map range.
+    var mapLocationPoints: [LocationPoint] = []
     var todayLocationPoints: [LocationPoint] = []
+    var locationPointCount = 0
+
+    private var allLocationPointsLoaded = false
 
     // UI State
     var mapDateRange: ClosedRange<Date> = Calendar.current.startOfDay(for: Date())...Date()
@@ -30,12 +37,14 @@ final class LocationViewModel {
 
         loadData()
         
-        // Observe location manager for new data points and reload when they're saved
+        // Observe location manager for new data points and append incrementally.
+        // Re-fetching every stored point after each GPS update becomes expensive
+        // once a user has a road trip worth of fixes saved locally.
         locationManager.$locationPointsSavedCount
             .dropFirst() // Skip initial value
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.loadTodayLocationPoints()
+                self?.appendLatestSavedLocationPoint()
             }
             .store(in: &cancellables)
     }
@@ -45,8 +54,9 @@ final class LocationViewModel {
     func loadData() {
         loadTodayVisits()
         loadAllVisits()
-        loadLocationPoints()
+        loadMapLocationPoints()
         loadTodayLocationPoints()
+        loadLocationPointCount()
     }
 
     func loadTodayVisits() {
@@ -81,15 +91,53 @@ final class LocationViewModel {
         }
     }
 
-    func loadLocationPoints() {
-        var descriptor = FetchDescriptor<LocationPoint>()
-        descriptor.sortBy = [SortDescriptor(\.timestamp, order: .forward)]
+    private func fetchLocationPoints(in range: ClosedRange<Date>? = nil) throws -> [LocationPoint] {
+        var descriptor: FetchDescriptor<LocationPoint>
 
+        if let range {
+            let start = range.lowerBound
+            let end = range.upperBound
+            let predicate = #Predicate<LocationPoint> { point in
+                point.timestamp >= start && point.timestamp <= end
+            }
+            descriptor = FetchDescriptor<LocationPoint>(predicate: predicate)
+        } else {
+            descriptor = FetchDescriptor<LocationPoint>()
+        }
+
+        descriptor.sortBy = [SortDescriptor(\.timestamp, order: .forward)]
+        return try modelContext.fetch(descriptor)
+    }
+
+    /// Loads all stored points for export-related screens only.
+    func loadLocationPoints() {
         do {
-            locationPoints = try modelContext.fetch(descriptor)
+            locationPoints = try fetchLocationPoints()
+            locationPointCount = locationPoints.count
+            allLocationPointsLoaded = true
         } catch {
             print("Failed to fetch location points: \(error)")
             locationPoints = []
+            allLocationPointsLoaded = false
+        }
+    }
+
+    func loadMapLocationPoints() {
+        do {
+            mapLocationPoints = try fetchLocationPoints(in: mapDateRange)
+        } catch {
+            print("Failed to fetch map location points: \(error)")
+            mapLocationPoints = []
+        }
+    }
+
+    func loadLocationPointCount() {
+        do {
+            let descriptor = FetchDescriptor<LocationPoint>()
+            locationPointCount = try modelContext.fetchCount(descriptor)
+        } catch {
+            print("Failed to count location points: \(error)")
+            locationPointCount = locationPoints.count
         }
     }
 
@@ -110,6 +158,42 @@ final class LocationViewModel {
         } catch {
             print("Failed to fetch today's location points: \(error)")
             todayLocationPoints = []
+        }
+    }
+
+    private func appendLatestSavedLocationPoint() {
+        guard let point = locationManager.latestSavedLocationPoint else {
+            loadTodayLocationPoints()
+            loadMapLocationPoints()
+            loadLocationPointCount()
+            return
+        }
+
+        locationPointCount += 1
+
+        if allLocationPointsLoaded {
+            append(point, to: &locationPoints)
+        }
+
+        if Calendar.current.isDate(point.timestamp, inSameDayAs: Date()) {
+            append(point, to: &todayLocationPoints)
+        }
+
+        if mapDateRange.contains(point.timestamp) {
+            append(point, to: &mapLocationPoints)
+        }
+    }
+
+    private func append(_ point: LocationPoint, to points: inout [LocationPoint]) {
+        if points.contains(where: { $0.id == point.id }) {
+            return
+        }
+
+        if let last = points.last, last.timestamp > point.timestamp {
+            points.append(point)
+            points.sort { $0.timestamp < $1.timestamp }
+        } else {
+            points.append(point)
         }
     }
 
@@ -239,7 +323,16 @@ final class LocationViewModel {
     }
 
     func locationPointsInDateRange(_ range: ClosedRange<Date>) -> [LocationPoint] {
-        locationPoints.filter { range.contains($0.timestamp) }
+        if allLocationPointsLoaded {
+            return locationPoints.filter { range.contains($0.timestamp) }
+        }
+
+        do {
+            return try fetchLocationPoints(in: range)
+        } catch {
+            print("Failed to fetch location points in range: \(error)")
+            return []
+        }
     }
 
     // MARK: - Visit Management
@@ -277,6 +370,7 @@ final class LocationViewModel {
         if let range = dateRange {
             pointsToExport = locationPointsInDateRange(range)
         } else {
+            loadLocationPoints()
             pointsToExport = locationPoints
         }
 
@@ -288,6 +382,7 @@ final class LocationViewModel {
     }
 
     func exportAllData(format: ExportFormat) {
+        loadLocationPoints()
         do {
             try ExportService.shareCombined(visits: allVisits, points: locationPoints, format: format)
         } catch {
@@ -297,6 +392,7 @@ final class LocationViewModel {
 
     @MainActor
     func exportWithOptions(_ options: ExportOptions) {
+        loadLocationPoints()
         do {
             try ExportService.share(visits: allVisits, points: locationPoints, options: options)
         } catch {
@@ -347,6 +443,8 @@ final class LocationViewModel {
         }
 
         try modelContext.save()
+        locationPoints = []
+        allLocationPointsLoaded = false
         loadData()
 
         return ImportResult(visitCount: result.visits.count, pointCount: result.points.count)
@@ -359,6 +457,11 @@ final class LocationViewModel {
             try modelContext.delete(model: Visit.self)
             try modelContext.delete(model: LocationPoint.self)
             try modelContext.save()
+            locationPoints = []
+            mapLocationPoints = []
+            todayLocationPoints = []
+            locationPointCount = 0
+            allLocationPointsLoaded = true
             loadData()
         } catch {
             print("Failed to clear data: \(error)")

--- a/IsoMe/Views/ExportView.swift
+++ b/IsoMe/Views/ExportView.swift
@@ -108,6 +108,14 @@ struct ExportView: View {
             .sheet(isPresented: $showingPaywall) {
                 PaywallView(storeManager: storeManager)
             }
+            .onAppear {
+                loadExportCacheIfUnlocked()
+            }
+            .onChange(of: storeManager.isPurchased) { _, isPurchased in
+                if isPurchased {
+                    loadExportCacheIfUnlocked()
+                }
+            }
         }
     }
 
@@ -971,7 +979,15 @@ struct ExportView: View {
 
     // MARK: - Actions
 
+    private func loadExportCacheIfUnlocked() {
+        guard storeManager.isPurchased else { return }
+        viewModel.loadAllVisits()
+        viewModel.loadLocationPoints()
+    }
+
     private func runExport() {
+        loadExportCacheIfUnlocked()
+
         if exportFolderManager.hasDefaultFolder && useDefaultExportFolder {
             do {
                 let urls = try ExportService.saveToDefaultFolder(

--- a/IsoMe/Views/MapView.swift
+++ b/IsoMe/Views/MapView.swift
@@ -32,13 +32,16 @@ struct LocationMapView: View {
 
     // Minimum distance in meters between points to show as markers
     private let minimumPointDistance: Double = 50
+    // Keep MapKit overlays/annotations bounded for multi-day road trips.
+    private let maximumPolylinePoints = 2_500
+    private let maximumPointMarkers = 500
 
     var filteredVisits: [Visit] {
         viewModel.visitsInDateRange(viewModel.mapDateRange)
     }
 
     var filteredPoints: [LocationPoint] {
-        let points = viewModel.locationPointsInDateRange(viewModel.mapDateRange)
+        let points = viewModel.mapLocationPoints
         return showOutliers ? points : points.filter { !$0.isOutlier }
     }
 
@@ -48,21 +51,20 @@ struct LocationMapView: View {
         return showOutliers ? points : points.filter { !$0.isOutlier }
     }
     
+    var displayPathPoints: [LocationPoint] {
+        LocationPointSampler.downsample(filteredPoints, maximumCount: maximumPolylinePoints)
+    }
+
+    var displaySessionPathPoints: [LocationPoint] {
+        LocationPointSampler.downsample(activeSessionPoints, maximumCount: maximumPolylinePoints)
+    }
+
     var spacedPoints: [LocationPoint] {
-        guard !filteredPoints.isEmpty else { return [] }
-        
-        var result: [LocationPoint] = [filteredPoints[0]]
-        
-        for point in filteredPoints.dropFirst() {
-            if let lastPoint = result.last {
-                let distance = lastPoint.distance(to: point)
-                if distance >= minimumPointDistance {
-                    result.append(point)
-                }
-            }
-        }
-        
-        return result
+        LocationPointSampler.spaced(
+            filteredPoints,
+            minimumDistance: minimumPointDistance,
+            maximumCount: maximumPointMarkers
+        )
     }
 
     var body: some View {
@@ -73,8 +75,8 @@ struct LocationMapView: View {
                     UserAnnotation()
 
                     // Travel path from location points
-                    if showTravelPath && !filteredPoints.isEmpty {
-                        let coordinates = filteredPoints.map { $0.coordinate }
+                    if showTravelPath && !displayPathPoints.isEmpty {
+                        let coordinates = displayPathPoints.map { $0.coordinate }
                         MapPolyline(coordinates: coordinates)
                             .stroke(
                                 LinearGradient(
@@ -87,8 +89,8 @@ struct LocationMapView: View {
                     }
                     
                     // Live session path (moved from Track tab)
-                    if showSessionPath && activeSessionPoints.count >= 2 {
-                        let sessionCoordinates = activeSessionPoints.map { $0.coordinate }
+                    if showSessionPath && displaySessionPathPoints.count >= 2 {
+                        let sessionCoordinates = displaySessionPathPoints.map { $0.coordinate }
                         MapPolyline(coordinates: sessionCoordinates)
                             .stroke(.blue, style: StrokeStyle(lineWidth: 5, lineCap: .round, lineJoin: .round))
                     }
@@ -257,12 +259,18 @@ struct LocationMapView: View {
             }
             .onAppear {
                 viewModel.loadAllVisits()
-                viewModel.loadLocationPoints()
+                viewModel.loadMapLocationPoints()
 
                 if locationManager.isTrackingEnabled {
                     pendingSessionAutoFocus = true
                     attemptAutoFocusSession()
                 }
+            }
+            .onChange(of: viewModel.mapDateRange.lowerBound) { _, _ in
+                viewModel.loadMapLocationPoints()
+            }
+            .onChange(of: viewModel.mapDateRange.upperBound) { _, _ in
+                viewModel.loadMapLocationPoints()
             }
             .onChange(of: locationManager.isTrackingEnabled) { _, isEnabled in
                 pendingSessionAutoFocus = isEnabled
@@ -1114,6 +1122,53 @@ struct FitMenuButton: View {
         }
         .accessibilityLabel("Fit map")
         .accessibilityHint("Shows options for zooming the map to available content.")
+    }
+}
+
+// MARK: - Point Sampling
+
+enum LocationPointSampler {
+    static func downsample(_ points: [LocationPoint], maximumCount: Int) -> [LocationPoint] {
+        guard maximumCount > 0 else { return [] }
+        guard points.count > maximumCount else { return points }
+        guard maximumCount > 1 else { return [points[0]] }
+
+        let step = Double(points.count - 1) / Double(maximumCount - 1)
+        var result: [LocationPoint] = []
+        result.reserveCapacity(maximumCount)
+        var previousIndex: Int?
+
+        for sampleIndex in 0..<maximumCount {
+            let sourceIndex = min(points.count - 1, Int((Double(sampleIndex) * step).rounded()))
+            guard sourceIndex != previousIndex else { continue }
+            result.append(points[sourceIndex])
+            previousIndex = sourceIndex
+        }
+
+        if result.last?.id != points.last?.id {
+            result[result.count - 1] = points[points.count - 1]
+        }
+
+        return result
+    }
+
+    static func spaced(
+        _ points: [LocationPoint],
+        minimumDistance: Double,
+        maximumCount: Int
+    ) -> [LocationPoint] {
+        guard !points.isEmpty else { return [] }
+
+        var result: [LocationPoint] = [points[0]]
+
+        for point in points.dropFirst() {
+            guard let lastPoint = result.last else { continue }
+            if lastPoint.distance(to: point) >= minimumDistance {
+                result.append(point)
+            }
+        }
+
+        return downsample(result, maximumCount: maximumCount)
     }
 }
 

--- a/IsoMe/Views/MapView.swift
+++ b/IsoMe/Views/MapView.swift
@@ -17,7 +17,6 @@ struct LocationMapView: View {
     @State private var showVisitMarkers = true
     @State private var cameraPosition: MapCameraPosition = .userLocation(fallback: .automatic)
     @State private var pendingSessionAutoFocus = false
-    @State private var activePreset: MapDatePreset? = .today
     @AppStorage("showOutliers") private var showOutliers = false
     @AppStorage("discordPromoDismissed") private var discordPromoDismissed = false
 
@@ -202,7 +201,7 @@ struct LocationMapView: View {
                     HStack(spacing: 8) {
                         if showFilterBar {
                             QuickFilterBar(
-                                activePreset: activePreset,
+                                activePreset: viewModel.activeMapPreset,
                                 showTravelPath: $showTravelPath,
                                 showPointMarkers: $showPointMarkers,
                                 showStartEndMarkers: $showStartEndMarkers,
@@ -210,8 +209,7 @@ struct LocationMapView: View {
                                 showVisitMarkers: $showVisitMarkers,
                                 hasSessionPoints: !activeSessionPoints.isEmpty,
                                 onSelectPreset: { preset in
-                                    activePreset = preset
-                                    viewModel.mapDateRange = preset.range()
+                                    viewModel.selectMapPreset(preset)
                                 },
                                 onSelectCustom: {
                                     showingFilters = true
@@ -248,9 +246,11 @@ struct LocationMapView: View {
             .toolbar(.hidden, for: .navigationBar)
             .sheet(isPresented: $showingFilters) {
                 DateRangeFilterSheet(
-                    dateRange: $viewModel.mapDateRange,
-                    isPresented: $showingFilters,
-                    onApply: { activePreset = nil }
+                    dateRange: Binding(
+                        get: { viewModel.mapDateRange },
+                        set: { viewModel.setCustomMapDateRange($0) }
+                    ),
+                    isPresented: $showingFilters
                 )
             }
             .sheet(item: $selectedVisit) { visit in
@@ -265,12 +265,6 @@ struct LocationMapView: View {
                     pendingSessionAutoFocus = true
                     attemptAutoFocusSession()
                 }
-            }
-            .onChange(of: viewModel.mapDateRange.lowerBound) { _, _ in
-                viewModel.loadMapLocationPoints()
-            }
-            .onChange(of: viewModel.mapDateRange.upperBound) { _, _ in
-                viewModel.loadMapLocationPoints()
             }
             .onChange(of: locationManager.isTrackingEnabled) { _, isEnabled in
                 pendingSessionAutoFocus = isEnabled
@@ -905,9 +899,11 @@ enum MapDatePreset: CaseIterable, Hashable {
         case .today:
             return calendar.startOfDay(for: referenceDate)...referenceDate
         case .sevenDays:
-            return calendar.date(byAdding: .day, value: -7, to: referenceDate)!...referenceDate
+            let start = calendar.date(byAdding: .day, value: -7, to: calendar.startOfDay(for: referenceDate))!
+            return start...referenceDate
         case .thirtyDays:
-            return calendar.date(byAdding: .day, value: -30, to: referenceDate)!...referenceDate
+            let start = calendar.date(byAdding: .day, value: -30, to: calendar.startOfDay(for: referenceDate))!
+            return start...referenceDate
         case .all:
             return Date.distantPast...referenceDate
         }

--- a/IsoMe/Views/SettingsView.swift
+++ b/IsoMe/Views/SettingsView.swift
@@ -82,6 +82,9 @@ struct SettingsView: View {
             ) { result in
                 handleImportResult(result)
             }
+            .onAppear {
+                viewModel.loadLocationPointCount()
+            }
             .onChange(of: usesMetricDistanceUnits) { _, _ in
                 locationManager.refreshDistanceUnitPreference()
             }
@@ -415,7 +418,7 @@ struct SettingsView: View {
                                 .tracking(1)
                                 .foregroundStyle(TE.textPrimary)
                             Spacer()
-                            Text("\(viewModel.locationPoints.count)")
+                            Text("\(viewModel.locationPointCount)")
                                 .font(TE.mono(.caption2, weight: .medium))
                                 .foregroundStyle(TE.textMuted)
                         }

--- a/IsoMeTests/LocationManagerTrackingTests.swift
+++ b/IsoMeTests/LocationManagerTrackingTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import CoreLocation
+import SwiftData
 @testable import IsoMe
 
 /// Tests that the LocationManager tracking lifecycle is correct:
@@ -88,5 +89,214 @@ final class LocationManagerTrackingTests: XCTestCase {
         manager.setLiveActivityEnabled(false)
         let fresh = LocationManager()
         XCTAssertFalse(fresh.isLiveActivityEnabled)
+    }
+}
+
+@MainActor
+final class LocationViewModelLoadTests: XCTestCase {
+    private let stressPointCount = 33_000
+    private let millionPointStressTestCount = 1_000_000
+    private let millionPointStressTestEnvKey = "ISOME_RUN_MILLION_POINT_STRESS_TEST"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: "isTrackingEnabled")
+        UserDefaults.standard.removeObject(forKey: "stopAfterHours")
+        UserDefaults.standard.removeObject(forKey: "distanceFilter")
+        UserDefaults.standard.removeObject(forKey: "isLiveActivityEnabled")
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "isTrackingEnabled")
+        UserDefaults.standard.removeObject(forKey: "stopAfterHours")
+        UserDefaults.standard.removeObject(forKey: "distanceFilter")
+        UserDefaults.standard.removeObject(forKey: "isLiveActivityEnabled")
+        super.tearDown()
+    }
+
+    func testStartupWithThirtyThreeThousandHistoricalPointsDoesNotEagerlyLoadFullPointCache() throws {
+        let container = try makeContainer()
+        let tripRange = try seedLocationPoints(
+            count: stressPointCount,
+            into: container.mainContext,
+            start: Date().addingTimeInterval(-7 * 86_400)
+        )
+
+        let viewModel = LocationViewModel(
+            modelContext: container.mainContext,
+            locationManager: LocationManager()
+        )
+
+        XCTAssertEqual(viewModel.locationPointCount, stressPointCount)
+        XCTAssertTrue(viewModel.locationPoints.isEmpty, "Startup should not load every historical point into the export cache.")
+        XCTAssertTrue(viewModel.mapLocationPoints.isEmpty, "Default Today map range should not load old road-trip points.")
+        XCTAssertTrue(viewModel.todayLocationPoints.isEmpty, "Historical points should not inflate today's live stats.")
+
+        viewModel.mapDateRange = tripRange
+        viewModel.loadMapLocationPoints()
+
+        XCTAssertEqual(viewModel.mapLocationPoints.count, stressPointCount)
+        XCTAssertTrue(viewModel.locationPoints.isEmpty, "Loading a large selected map range should not populate the full export cache.")
+    }
+
+    func testOnDemandExportLoadStillFetchesThirtyThreeThousandPoints() throws {
+        let container = try makeContainer()
+        try seedLocationPoints(
+            count: stressPointCount,
+            into: container.mainContext,
+            start: Date().addingTimeInterval(-7 * 86_400)
+        )
+
+        let viewModel = LocationViewModel(
+            modelContext: container.mainContext,
+            locationManager: LocationManager()
+        )
+
+        XCTAssertTrue(viewModel.locationPoints.isEmpty)
+
+        viewModel.loadLocationPoints()
+
+        XCTAssertEqual(viewModel.locationPoints.count, stressPointCount)
+        XCTAssertEqual(viewModel.locationPointCount, stressPointCount)
+    }
+
+    func testMapViewDownsamplesThirtyThreeThousandSelectedPointsForRendering() throws {
+        let container = try makeContainer()
+        let viewModel = LocationViewModel(
+            modelContext: container.mainContext,
+            locationManager: LocationManager()
+        )
+        viewModel.mapLocationPoints = makeDetachedPoints(count: stressPointCount)
+
+        let mapView = LocationMapView(viewModel: viewModel)
+
+        XCTAssertEqual(mapView.filteredPoints.count, stressPointCount)
+        XCTAssertEqual(mapView.displayPathPoints.count, 2_500)
+        XCTAssertLessThanOrEqual(mapView.spacedPoints.count, 500)
+        XCTAssertEqual(mapView.displayPathPoints.first?.id, viewModel.mapLocationPoints.first?.id)
+        XCTAssertEqual(mapView.displayPathPoints.last?.id, viewModel.mapLocationPoints.last?.id)
+    }
+
+    func testManualMillionPointStartupDoesNotEagerlyLoadFullPointCache() throws {
+        guard ProcessInfo.processInfo.environment[millionPointStressTestEnvKey] == "1" else {
+            throw XCTSkip("Set \(millionPointStressTestEnvKey)=1 to run the 1,000,000-point startup stress test.")
+        }
+
+        let container = try makeContainer()
+        try seedLocationPoints(
+            count: millionPointStressTestCount,
+            into: container,
+            start: Date().addingTimeInterval(-30 * 86_400),
+            batchSize: 10_000
+        )
+
+        let viewModel = LocationViewModel(
+            modelContext: container.mainContext,
+            locationManager: LocationManager()
+        )
+
+        XCTAssertEqual(viewModel.locationPointCount, millionPointStressTestCount)
+        XCTAssertTrue(viewModel.locationPoints.isEmpty, "Startup should not load one million historical points into the export cache.")
+        XCTAssertTrue(viewModel.mapLocationPoints.isEmpty, "Default Today map range should not load old stress-test points.")
+        XCTAssertTrue(viewModel.todayLocationPoints.isEmpty, "Historical stress-test points should not inflate today's live stats.")
+    }
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([Visit.self, LocationPoint.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    @discardableResult
+    private func seedLocationPoints(
+        count: Int,
+        into context: ModelContext,
+        start: Date
+    ) throws -> ClosedRange<Date> {
+        let interval: TimeInterval = 5
+        for index in 0..<count {
+            context.insert(makePoint(index: index, start: start, interval: interval))
+        }
+        try context.save()
+
+        let end = start.addingTimeInterval(Double(max(0, count - 1)) * interval)
+        return start...end
+    }
+
+    @discardableResult
+    private func seedLocationPoints(
+        count: Int,
+        into container: ModelContainer,
+        start: Date,
+        batchSize: Int
+    ) throws -> ClosedRange<Date> {
+        let interval: TimeInterval = 5
+
+        for batchStart in stride(from: 0, to: count, by: batchSize) {
+            let context = ModelContext(container)
+            let batchEnd = min(batchStart + batchSize, count)
+            for index in batchStart..<batchEnd {
+                context.insert(makePoint(index: index, start: start, interval: interval))
+            }
+            try context.save()
+        }
+
+        let end = start.addingTimeInterval(Double(max(0, count - 1)) * interval)
+        return start...end
+    }
+
+    private func makeDetachedPoints(count: Int) -> [LocationPoint] {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        return (0..<count).map { makePoint(index: $0, start: start, interval: 5) }
+    }
+
+    private func makePoint(index: Int, start: Date, interval: TimeInterval) -> LocationPoint {
+        LocationPoint(
+            latitude: 37.0 + Double(index % 1_000) * 0.0001,
+            longitude: -122.0 + Double(index / 1_000) * 0.0001,
+            timestamp: start.addingTimeInterval(Double(index) * interval),
+            horizontalAccuracy: 5
+        )
+    }
+}
+
+final class LocationPointSamplerTests: XCTestCase {
+    func testDownsampleCapsPointCountAndPreservesEndpoints() {
+        let points = makePoints(count: 33_000)
+
+        let sampled = LocationPointSampler.downsample(points, maximumCount: 2_500)
+
+        XCTAssertLessThanOrEqual(sampled.count, 2_500)
+        XCTAssertEqual(sampled.first?.id, points.first?.id)
+        XCTAssertEqual(sampled.last?.id, points.last?.id)
+    }
+
+    func testSpacedCapsMarkerCountAndPreservesStart() {
+        let points = makePoints(count: 10_000, latitudeStep: 0.001)
+
+        let sampled = LocationPointSampler.spaced(
+            points,
+            minimumDistance: 50,
+            maximumCount: 500
+        )
+
+        XCTAssertLessThanOrEqual(sampled.count, 500)
+        XCTAssertEqual(sampled.first?.id, points.first?.id)
+    }
+
+    func testDownsampleWithZeroMaximumReturnsNoPoints() {
+        XCTAssertTrue(LocationPointSampler.downsample(makePoints(count: 10), maximumCount: 0).isEmpty)
+    }
+
+    private func makePoints(count: Int, latitudeStep: Double = 0.0001) -> [LocationPoint] {
+        let startDate = Date(timeIntervalSince1970: 1_700_000_000)
+        return (0..<count).map { index in
+            LocationPoint(
+                latitude: 37.0 + Double(index) * latitudeStep,
+                longitude: -122.0,
+                timestamp: startDate.addingTimeInterval(Double(index)),
+                horizontalAccuracy: 5
+            )
+        }
     }
 }

--- a/IsoMeTests/LocationManagerTrackingTests.swift
+++ b/IsoMeTests/LocationManagerTrackingTests.swift
@@ -177,6 +177,49 @@ final class LocationViewModelLoadTests: XCTestCase {
         XCTAssertEqual(mapView.displayPathPoints.last?.id, viewModel.mapLocationPoints.last?.id)
     }
 
+    func testAppendingPointAcrossMidnightReloadsTodayCache() throws {
+        let calendar = Calendar.current
+        let todayStart = calendar.startOfDay(for: Date())
+        let yesterdayReference = calendar.date(byAdding: .day, value: -1, to: todayStart)!.addingTimeInterval(60)
+        let todayReference = todayStart.addingTimeInterval(60)
+
+        let container = try makeContainer()
+        let context = container.mainContext
+        let yesterdayPoint = LocationPoint(
+            latitude: 37.0,
+            longitude: -122.0,
+            timestamp: yesterdayReference,
+            horizontalAccuracy: 5
+        )
+        context.insert(yesterdayPoint)
+        try context.save()
+
+        let manager = LocationManager()
+        let viewModel = LocationViewModel(
+            modelContext: context,
+            locationManager: manager
+        )
+        viewModel.loadTodayLocationPoints(referenceDate: yesterdayReference)
+        XCTAssertEqual(viewModel.todayLocationPoints.map(\.id), [yesterdayPoint.id])
+
+        let todayPoint = LocationPoint(
+            latitude: 37.1,
+            longitude: -122.1,
+            timestamp: todayReference,
+            horizontalAccuracy: 5
+        )
+        context.insert(todayPoint)
+        try context.save()
+        let pointCountBeforeAppend = viewModel.locationPointCount
+
+        manager.latestSavedLocationPoint = todayPoint
+        viewModel.appendLatestSavedLocationPoint(referenceDate: todayReference)
+
+        XCTAssertEqual(viewModel.todayLocationPoints.map(\.id), [todayPoint.id])
+        XCTAssertFalse(viewModel.todayLocationPoints.contains { $0.id == yesterdayPoint.id })
+        XCTAssertEqual(viewModel.locationPointCount, pointCountBeforeAppend + 1)
+    }
+
     func testManualMillionPointStartupDoesNotEagerlyLoadFullPointCache() throws {
         guard ProcessInfo.processInfo.environment[millionPointStressTestEnvKey] == "1" else {
             throw XCTSkip("Set \(millionPointStressTestEnvKey)=1 to run the 1,000,000-point startup stress test.")

--- a/IsoMeTests/LocationManagerTrackingTests.swift
+++ b/IsoMeTests/LocationManagerTrackingTests.swift
@@ -132,8 +132,7 @@ final class LocationViewModelLoadTests: XCTestCase {
         XCTAssertTrue(viewModel.mapLocationPoints.isEmpty, "Default Today map range should not load old road-trip points.")
         XCTAssertTrue(viewModel.todayLocationPoints.isEmpty, "Historical points should not inflate today's live stats.")
 
-        viewModel.mapDateRange = tripRange
-        viewModel.loadMapLocationPoints()
+        viewModel.setCustomMapDateRange(tripRange)
 
         XCTAssertEqual(viewModel.mapLocationPoints.count, stressPointCount)
         XCTAssertTrue(viewModel.locationPoints.isEmpty, "Loading a large selected map range should not populate the full export cache.")
@@ -200,7 +199,9 @@ final class LocationViewModelLoadTests: XCTestCase {
             locationManager: manager
         )
         viewModel.loadTodayLocationPoints(referenceDate: yesterdayReference)
+        viewModel.selectMapPreset(.today, referenceDate: yesterdayReference)
         XCTAssertEqual(viewModel.todayLocationPoints.map(\.id), [yesterdayPoint.id])
+        XCTAssertEqual(viewModel.mapLocationPoints.map(\.id), [yesterdayPoint.id])
 
         let todayPoint = LocationPoint(
             latitude: 37.1,
@@ -217,7 +218,73 @@ final class LocationViewModelLoadTests: XCTestCase {
 
         XCTAssertEqual(viewModel.todayLocationPoints.map(\.id), [todayPoint.id])
         XCTAssertFalse(viewModel.todayLocationPoints.contains { $0.id == yesterdayPoint.id })
+        XCTAssertEqual(viewModel.mapLocationPoints.map(\.id), [todayPoint.id])
+        XCTAssertFalse(viewModel.mapLocationPoints.contains { $0.id == yesterdayPoint.id })
         XCTAssertEqual(viewModel.locationPointCount, pointCountBeforeAppend + 1)
+    }
+
+    func testAppendingPointRefreshesActiveMapPresetRangeBeforeUpdatingMapCache() throws {
+        let calendar = Calendar.current
+        let todayStart = calendar.startOfDay(for: Date())
+        let initialReference = todayStart.addingTimeInterval(60)
+        let laterReference = todayStart.addingTimeInterval(600)
+
+        let container = try makeContainer()
+        let context = container.mainContext
+        let manager = LocationManager()
+        let viewModel = LocationViewModel(
+            modelContext: context,
+            locationManager: manager
+        )
+        viewModel.selectMapPreset(.today, referenceDate: initialReference)
+        XCTAssertFalse(viewModel.mapDateRange.contains(laterReference))
+
+        let laterPoint = LocationPoint(
+            latitude: 37.2,
+            longitude: -122.2,
+            timestamp: laterReference,
+            horizontalAccuracy: 5
+        )
+        context.insert(laterPoint)
+        try context.save()
+
+        manager.latestSavedLocationPoint = laterPoint
+        viewModel.appendLatestSavedLocationPoint(referenceDate: laterReference)
+
+        XCTAssertTrue(viewModel.mapDateRange.contains(laterPoint.timestamp))
+        XCTAssertEqual(viewModel.mapLocationPoints.map(\.id), [laterPoint.id])
+    }
+
+    func testAppendingPointDoesNotExpandCustomMapDateRange() throws {
+        let calendar = Calendar.current
+        let todayStart = calendar.startOfDay(for: Date())
+        let rangeEnd = todayStart.addingTimeInterval(60)
+        let laterReference = todayStart.addingTimeInterval(600)
+
+        let container = try makeContainer()
+        let context = container.mainContext
+        let manager = LocationManager()
+        let viewModel = LocationViewModel(
+            modelContext: context,
+            locationManager: manager
+        )
+        viewModel.setCustomMapDateRange(todayStart...rangeEnd)
+
+        let laterPoint = LocationPoint(
+            latitude: 37.3,
+            longitude: -122.3,
+            timestamp: laterReference,
+            horizontalAccuracy: 5
+        )
+        context.insert(laterPoint)
+        try context.save()
+
+        manager.latestSavedLocationPoint = laterPoint
+        viewModel.appendLatestSavedLocationPoint(referenceDate: laterReference)
+
+        XCTAssertNil(viewModel.activeMapPreset)
+        XCTAssertFalse(viewModel.mapDateRange.contains(laterPoint.timestamp))
+        XCTAssertTrue(viewModel.mapLocationPoints.isEmpty)
     }
 
     func testManualMillionPointStartupDoesNotEagerlyLoadFullPointCache() throws {


### PR DESCRIPTION
## Summary
- Avoid eager-loading all historical location points on app/map startup
- Add map-specific point cache and incremental append path for new GPS fixes
- Downsample large map paths to 2,500 polyline points and cap point markers at 500
- Keep full point loading available on demand for export flows
- Add 33k-point regression/load tests plus an opt-in 1M-point manual stress test

## Tests
- `xcodebuild test -project IsoMe.xcodeproj -scheme IsoMe -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -quiet`
- GitHub Actions workflow dispatch: https://github.com/CodyBontecou/isome/actions/runs/25977579253

## Manual stress test
Run the 1M-point startup stress test only when needed:

```bash
ISOME_RUN_MILLION_POINT_STRESS_TEST=1 \
xcodebuild test \
  -project IsoMe.xcodeproj \
  -scheme IsoMe \
  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' \
  -only-testing:IsoMeTests/LocationViewModelLoadTests/testManualMillionPointStartupDoesNotEagerlyLoadFullPointCache
```
